### PR TITLE
First version of the `rowan_nom` cross-integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ariadne"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7080ae01b2f0c312065d4914cd0f0de045eb8832e9415b355106a6cff3073cb4"
+checksum = "f1cb2a2046bea8ce5e875551f5772024882de0b540c7f93dfc5d6cf1ca8b030c"
 dependencies = [
  "yansi",
 ]
@@ -36,6 +36,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
+name = "enum-ordinalize"
+version = "3.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62bb1df8b45ecb7ffa78dca1c17a438fb193eb083db0b1b494d2a61bcb5096a"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,9 +57,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "logos"
@@ -93,43 +107,73 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.40"
+name = "num-bigint"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rowan"
-version = "0.15.5"
+version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1f383129e417a6265b16ed78e6e9307748f0863b2ba75f78ff14717db5b017"
+checksum = "5811547e7ba31e903fe48c8ceab10d40d70a101f3d15523c847cce91aa71f332"
 dependencies = [
  "countme",
  "hashbrown",
@@ -145,6 +189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustre-ast-dump"
 version = "0.1.0"
 dependencies = [
@@ -158,17 +211,34 @@ name = "rustre-parser"
 version = "0.1.0"
 dependencies = [
  "case",
+ "enum-ordinalize",
  "logos",
  "nom",
  "rowan",
+ "rustre-parser-tests-codegen",
+ "thiserror",
  "ungrammar",
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.98"
+name = "rustre-parser-tests-codegen"
+version = "0.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+
+[[package]]
+name = "syn"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -182,6 +252,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "288cb548dbe72b652243ea797201f3d481a0609a967980fcc5b2315ea811560a"
 
 [[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ungrammar"
 version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,12 +279,12 @@ checksum = "a3e5df347f0bf3ec1d670aad6ca5c6a1859cd9ea61d2113125794654ccced68f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "yansi"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,12 +71,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -137,6 +159,7 @@ version = "0.1.0"
 dependencies = [
  "case",
  "logos",
+ "nom",
  "rowan",
  "ungrammar",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
-    "rustre-parser",
     "rustre-ast-dump",
+    "rustre-parser",
+    "rustre-parser-tests-codegen",
 ]

--- a/compat.sh
+++ b/compat.sh
@@ -46,4 +46,5 @@ for f in $(find $LUSTRE_DIR/test/should_fail/ -type f); do
 done
 
 echo
-echo "Total: $ok / $tot"
+percent_total=$(awk "BEGIN {printf \"%.2f\n\", 100 * $ok / $tot}")
+echo "Total: $ok / $tot ($percent_total%)"

--- a/compat.sh
+++ b/compat.sh
@@ -21,6 +21,7 @@ echo
 
 for f in $(find $LUSTRE_DIR/test/should_work/ -type f); do
     ((tot=$tot+1))
+    echo -en "[RUNN] $f\r"
     $BIN_PATH $f &> /dev/null
     if [ $? -eq 0 ]; then
         echo "[ OK ] $f"
@@ -35,6 +36,7 @@ echo "=== Should fail ==="
 echo
 #Pour chaque test faudrait aussi faire une version où on rajoute du trivia entre tous les lexèmes non-trivia pour vérifier qu'on gère bien ça. Et à la limite un autre où on enlève le trivia qui pourrait être là (quitte à avoir une liste de lexèmes qui ne peuvent plus être serialisée vu que des idents ou kw peuvent se toucher)
 for f in $(find $LUSTRE_DIR/test/should_fail/ -type f); do
+    echo -en "[RUNN] $f\r"
     $BIN_PATH $f &> /dev/null
     ((tot=$tot+1))
     if [ $? -eq 0 ]; then

--- a/rustre-ast-dump/src/main.rs
+++ b/rustre-ast-dump/src/main.rs
@@ -6,7 +6,13 @@ use rustre_parser::{lexer::Token, Parse, SyntaxNode, SyntaxToken};
 
 fn main() -> Result<(), u8> {
     let file = std::env::args().nth(1).expect("please give a file name");
-    let contents = std::fs::read_to_string(&file).unwrap();
+    let mut contents = std::fs::read_to_string(&file).unwrap();
+
+    // Remove when comments as last tokens are properly parsed
+    if !contents.ends_with('\n') {
+        contents += "\n";
+    }
+
     let Parse { root, errors } = rustre_parser::Parse::parse(&contents);
     print(0, root.into());
 

--- a/rustre-parser-tests-codegen/Cargo.toml
+++ b/rustre-parser-tests-codegen/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rustre-parser-tests-codegen"
+description = "rustre-parser module that generates test cases for each test file in the upstream lustre-v6 repository"
+version = "0.0.0" # doesn't need incrementing
+edition = "2021"
+license = "GPL-3.0"
+
+[lib]
+proc-macro = true
+path = "lib.rs"
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"

--- a/rustre-parser-tests-codegen/lib.rs
+++ b/rustre-parser-tests-codegen/lib.rs
@@ -1,0 +1,117 @@
+use proc_macro2::{Ident, Literal, Span, TokenStream, TokenTree};
+use quote::quote;
+use std::path::{Path, PathBuf};
+
+fn build_test(path: PathBuf, should_fail: bool) -> TokenStream {
+    let path_displayed = path.canonicalize().unwrap().display().to_string();
+    let path_lit = Literal::string(&path_displayed);
+    let test_name = path
+        .file_stem()
+        .unwrap()
+        .to_str()
+        .expect("path isn't UTF-8")
+        .replace(['-', ' '], "_")
+        .to_lowercase();
+
+    let prefix = if should_fail {
+        "test_fail"
+    } else {
+        "test_success"
+    };
+
+    let test_fn_name = Ident::new(&format!("{prefix}_{test_name}"), Span::call_site());
+
+    if should_fail && path.extension() != Some("lus".as_ref()) {
+        return quote! {
+            #[test]
+            fn #test_fn_name() {
+                // File extension was not .lus, skipping
+            }
+        };
+    }
+
+    // TODO remove the concat! once we can lex end-of-file line comments
+    let parse_quote = quote! {
+        let source = concat!(include_str!(#path_lit), "\n");
+        let Parse { errors, .. } = Parse::parse(source);
+    };
+
+    if !should_fail {
+        quote! {
+            #[test]
+            fn #test_fn_name() {
+                #parse_quote
+                assert!(
+                    errors.is_empty(),
+                    "parsing file {:?} produced {} errors",
+                    #path_lit,
+                    errors.len(),
+                );
+            }
+        }
+    } else {
+        quote! {
+            #[test]
+            fn #test_fn_name() {
+                #parse_quote
+                assert!(
+                    !errors.is_empty(),
+                    "parsing file {:?} didn't produce any errors, but should have",
+                    #path_lit,
+                );
+            }
+        }
+    }
+}
+
+fn test_fns(lustre_v6_dir: &Path) -> impl Iterator<Item = TokenStream> {
+    let should_work_dir = lustre_v6_dir.join("test").join("should_work");
+    let should_fail_dir = lustre_v6_dir.join("test").join("should_fail");
+
+    [(should_work_dir, false), (should_fail_dir, true)]
+        .map(|(dir, should_fail)| {
+            dir.read_dir().unwrap().filter_map(move |entry| {
+                let entry = entry.unwrap();
+                let path = entry.path();
+
+                if matches!(path.metadata(), Ok(meta) if meta.is_file()) {
+                    Some(build_test(path, should_fail))
+                } else {
+                    None
+                }
+            })
+        })
+        .into_iter()
+        .flatten()
+}
+
+#[proc_macro]
+pub fn include_lustre_tests(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = TokenStream::from(input);
+
+    let tokens = input.into_iter().collect::<Vec<_>>();
+
+    assert_eq!(tokens.len(), 2);
+    assert!(matches!(&tokens[0], TokenTree::Ident(ident) if *ident == "mod"));
+    let mod_name = if let TokenTree::Ident(id) = &tokens[1] {
+        id
+    } else {
+        panic!("missing module name");
+    };
+
+    let lustre_v6_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("lustre-v6");
+
+    let test_fns = test_fns(&lustre_v6_dir);
+
+    let quoted = quote! {
+        mod #mod_name {
+            use super::*;
+            #(#test_fns)*
+        }
+    };
+
+    quoted.into()
+}

--- a/rustre-parser/Cargo.toml
+++ b/rustre-parser/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/elegaanz/rustre"
 
 [dependencies]
 logos = "0.12.1"
+nom = "7.1.1"
 rowan = "0.15.5"
 
 [build-dependencies]

--- a/rustre-parser/Cargo.toml
+++ b/rustre-parser/Cargo.toml
@@ -13,6 +13,9 @@ nom = "7.1.1"
 rowan = "0.15.5"
 thiserror = "1.0"
 
+[dev-dependencies]
+rustre-parser-tests-codegen = { path = "../rustre-parser-tests-codegen" }
+
 [build-dependencies]
 ungrammar = "1.16"
 case = "1.0.0"

--- a/rustre-parser/Cargo.toml
+++ b/rustre-parser/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/elegaanz/rustre"
 logos = "0.12.1"
 nom = "7.1.1"
 rowan = "0.15.5"
+thiserror = "1.0"
 
 [build-dependencies]
 ungrammar = "1.16"

--- a/rustre-parser/Cargo.toml
+++ b/rustre-parser/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0"
 repository = "https://github.com/elegaanz/rustre"
 
 [dependencies]
+enum-ordinalize = "3.1"
 logos = "0.12.1"
 nom = "7.1.1"
 rowan = "0.15.5"

--- a/rustre-parser/src/lexer.rs
+++ b/rustre-parser/src/lexer.rs
@@ -258,6 +258,14 @@ pub enum Token {
     Error,
 
     // Composite nodes
+    IdNode,
+    NodeNode,
+    PragmaNode,
+    ParamsNode,
+    BodyNode,
+    AssertEquationNode,
+    EqualsEquationNode,
+
     /// Children: IncludeStatement + PackageList or PackageBody
     Root,
     /// Children: Include + String
@@ -268,7 +276,6 @@ pub enum Token {
     PackageBody,
     ConstantDecl,
     TypeDecl,
-    EquationNode,
     ExpressionNode,
     ExternalNodeDecl,
     NodeDecl,

--- a/rustre-parser/src/lexer.rs
+++ b/rustre-parser/src/lexer.rs
@@ -56,7 +56,7 @@ pub enum Token {
     Current,
 
     #[token("#")]
-    Sharp,
+    Diese,
 
     #[token("div")]
     Div,
@@ -288,8 +288,12 @@ pub enum Token {
 
     // Ebnf group StaticRules
     StaticParamsNode,
+    StaticParamNode,
     EffectiveNodeNode,
     StaticArgsNode,
+    StaticArgNode,
+    NamedStaticArgsNode,
+    NamedStaticArgNode,
 
     // Ebnf group BodyRules
     BodyNode,
@@ -297,8 +301,66 @@ pub enum Token {
     EqualsEquationNode,
 
     // Ebnf group LeftRules
+    LeftNode,
+    LeftFieldAccessNode,
+    LeftTableAccessNode,
+    SelectNode,
+    StepNode,
 
     // Ebnf group ExpressionRules
+    ExpressionNode,
+
+    ParExpressionNode,
+    IdentExpressionNode,
+
+    FbyExpressionNode,
+
+    CallByPosExpressionNode,
+    ArrayAccessExpressionNode,
+
+    HatExpressionNode,
+    FieldAccessExpressionNode,
+
+    NegExpressionNode,
+    PreExpressionNode,
+    CurrentExpressionNode,
+    DieseExpressionNode,
+    NorExpressionNode,
+
+    IntExpressionNode,
+    RealExpressionNode,
+
+    WhenExpressionNode,
+
+    PowerExpressionNode,
+
+    MulExpressionNode,
+    DivExpressionNode,
+    ModExpressionNode,
+
+    AddExpressionNode,
+    SubExpressionNode,
+
+    NotExpressionNode,
+
+    LtExpressionNode,
+    LteExpressionNode,
+    EqExpressionNode,
+    GteExpressionNode,
+    GtExpressionNode,
+    NeqExpressionNode,
+
+    AndExpressionNode,
+    OrExpressionNode,
+    XorExpressionNode,
+
+    ImplExpressionNode,
+
+    ArrowExpressionNode,
+
+    ConcatExpressionNode,
+
+    IfExpressionNode,
 
     // Ebnf group MergeRules
 
@@ -316,7 +378,6 @@ pub enum Token {
     PackageBody,
     ConstantDecl,
     TypeDecl,
-    ExpressionNode,
     ExternalNodeDecl,
     NodeDecl,
     NodeAlias,
@@ -328,7 +389,6 @@ pub enum Token {
     ParamDecl,
     ParamsDecl,
     ReturnsNode,
-    StaticArgNode,
     VarDecl,
 }
 

--- a/rustre-parser/src/lexer.rs
+++ b/rustre-parser/src/lexer.rs
@@ -266,8 +266,14 @@ pub enum Token {
     IncludeStatement,
 
     // Ebnf group PackageRules
+    PackageDeclNode,
+    PackageDeclBody,
+    PackageAliasNode,
+    UsesNode,
 
     // Ebnf group ModelRules
+    ProvidesNode,
+    ModelDeclNode,
 
     // Ebnf group IdentRules
     IdNode,
@@ -382,22 +388,6 @@ pub enum Token {
 
     // Ebnf group ConstantRules
     ConstantNode,
-
-    /// A list of declarations
-    ///
-    /// Children: ConstantDecl, TypeDecl, ExternalNodeDecl, NodeDecl
-    PackageBody,
-    NodeDecl,
-    NodeAlias,
-    ModelDecl,
-    PackageAlias,
-    PackageDecl,
-    /// Children: ModelDecl, PackageDecl, PackageAlias
-    PackageList,
-    ParamDecl,
-    ParamsDecl,
-    ReturnsNode,
-    VarDecl,
 }
 
 impl From<Token> for rowan::SyntaxKind {

--- a/rustre-parser/src/lexer.rs
+++ b/rustre-parser/src/lexer.rs
@@ -169,7 +169,7 @@ pub enum Token {
     #[token("fby")]
     FBy,
 
-    #[regex(r"[0-9]+\.[0-9]+")] // TODO: this is incorrect
+    #[regex(r"[0-9]+\.[0-9]*")] // TODO: this is incorrect
     RConst,
 
     #[token("real")]
@@ -389,6 +389,8 @@ pub enum Token {
     PredefOp,
 
     // Ebnf group ExpressionByNamesRules
+    CallByNameExpressionNode,
+    CallByNameParamNode,
 
     // Ebnf group ConstantRules
     ConstantNode,

--- a/rustre-parser/src/lexer.rs
+++ b/rustre-parser/src/lexer.rs
@@ -4,7 +4,10 @@ use logos::{Lexer, Logos, SpannedIter};
 /// A token
 #[repr(u16)]
 pub enum Token {
-    #[regex("[ \t\n\r]")]
+    /// Whitespace character
+    ///
+    /// Includes: spaces, tabs, newlines, carriage returns, form feeds
+    #[regex("[ \t\n\r\u{0C}]")]
     Space,
 
     #[token("extern")]

--- a/rustre-parser/src/lexer.rs
+++ b/rustre-parser/src/lexer.rs
@@ -185,7 +185,11 @@ pub enum Token {
     #[token("fby")]
     FBy,
 
-    #[regex(r"\d+\.\d*")]
+    /// Recognizes a floating-point literal
+    ///
+    /// The regex is intentionally a bit greedy, but this gives room for better errors if the value
+    /// is unparseable.
+    #[regex(r"\d+\.\d*(e[+-]?\d+)?")]
     RConst,
 
     #[token("real")]

--- a/rustre-parser/src/lexer.rs
+++ b/rustre-parser/src/lexer.rs
@@ -258,18 +258,58 @@ pub enum Token {
     Error,
 
     // Composite nodes
+
+    // Ebnf group ProgramRules
+    Root,
+
+    /// Children: Include + String
+    IncludeStatement,
+
+    // Ebnf group PackageRules
+
+    // Ebnf group ModelRules
+
+    // Ebnf group IdentRules
     IdNode,
-    NodeNode,
     PragmaNode,
+
+    // Ebnf group NodesRules
+    NodeNode,
     ParamsNode,
+
+    // Ebnf group ConstantDeclRules
+
+    // Ebnf group TypeDeclRules
+
+    // Ebnf group SimpleTypeRules
+    TypeNode,
+
+    // Ebnf group ExtNodesRules
+
+    // Ebnf group StaticRules
+    StaticParamsNode,
+    EffectiveNodeNode,
+    StaticArgsNode,
+
+    // Ebnf group BodyRules
     BodyNode,
     AssertEquationNode,
     EqualsEquationNode,
 
-    /// Children: IncludeStatement + PackageList or PackageBody
-    Root,
-    /// Children: Include + String
-    IncludeStatement,
+    // Ebnf group LeftRules
+
+    // Ebnf group ExpressionRules
+
+    // Ebnf group MergeRules
+
+    // Ebnf group PredefRules
+    PredefOp,
+
+    // Ebnf group ExpressionByNamesRules
+
+    // Ebnf group ConstantRules
+    ConstantNode,
+
     /// A list of declarations
     ///
     /// Children: ConstantDecl, TypeDecl, ExternalNodeDecl, NodeDecl
@@ -288,10 +328,7 @@ pub enum Token {
     ParamDecl,
     ParamsDecl,
     ReturnsNode,
-    StaticArgsNode,
     StaticArgNode,
-    StaticParamsNode,
-    TypeNode,
     VarDecl,
 }
 

--- a/rustre-parser/src/lexer.rs
+++ b/rustre-parser/src/lexer.rs
@@ -326,6 +326,7 @@ pub enum Token {
     ExpressionNode,
 
     ParExpressionNode,
+    ArrayLiteralExpressionNode,
     IdentExpressionNode,
 
     FbyExpressionNode,

--- a/rustre-parser/src/lexer.rs
+++ b/rustre-parser/src/lexer.rs
@@ -274,12 +274,20 @@ pub enum Token {
     PragmaNode,
 
     // Ebnf group NodesRules
+    TypedLv6IdsNode,
+    TypedValuedLv6IdNode,
     NodeNode,
     ParamsNode,
 
     // Ebnf group ConstantDeclRules
+    ConstantDeclNode,
+    OneConstantDeclNode,
 
     // Ebnf group TypeDeclRules
+    TypeDeclNode,
+    OneTypeDeclNode,
+    EnumDeclNode,
+    StructDeclNode,
 
     // Ebnf group SimpleTypeRules
     TypeNode,
@@ -362,6 +370,8 @@ pub enum Token {
 
     IfExpressionNode,
 
+    ClockExpressionNode,
+
     // Ebnf group MergeRules
 
     // Ebnf group PredefRules
@@ -376,8 +386,6 @@ pub enum Token {
     ///
     /// Children: ConstantDecl, TypeDecl, ExternalNodeDecl, NodeDecl
     PackageBody,
-    ConstantDecl,
-    TypeDecl,
     ExternalNodeDecl,
     NodeDecl,
     NodeAlias,

--- a/rustre-parser/src/lexer.rs
+++ b/rustre-parser/src/lexer.rs
@@ -1,6 +1,7 @@
+use enum_ordinalize::Ordinalize;
 use logos::{Lexer, Logos, SpannedIter};
 
-#[derive(Logos, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone)]
+#[derive(Logos, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Ordinalize)]
 /// A token
 #[repr(u16)]
 pub enum Token {
@@ -466,11 +467,11 @@ impl rowan::Language for LustreLang {
     type Kind = Token;
 
     fn kind_from_raw(raw: rowan::SyntaxKind) -> Self::Kind {
-        unsafe { std::mem::transmute::<u16, Token>(raw.0) }
+        Token::from_ordinal(raw.0).unwrap()
     }
 
     fn kind_to_raw(kind: Self::Kind) -> rowan::SyntaxKind {
-        kind.into()
+        rowan::SyntaxKind(kind.ordinal())
     }
 }
 

--- a/rustre-parser/src/lexer.rs
+++ b/rustre-parser/src/lexer.rs
@@ -380,7 +380,10 @@ pub enum Token {
 
     ClockExpressionNode,
 
+    MergeExpressionNode,
+
     // Ebnf group MergeRules
+    MergeCaseNode,
 
     // Ebnf group PredefRules
     PredefOp,

--- a/rustre-parser/src/lexer.rs
+++ b/rustre-parser/src/lexer.rs
@@ -293,6 +293,7 @@ pub enum Token {
     TypeNode,
 
     // Ebnf group ExtNodesRules
+    ExternalNodeDeclNode,
 
     // Ebnf group StaticRules
     StaticParamsNode,
@@ -386,7 +387,6 @@ pub enum Token {
     ///
     /// Children: ConstantDecl, TypeDecl, ExternalNodeDecl, NodeDecl
     PackageBody,
-    ExternalNodeDecl,
     NodeDecl,
     NodeAlias,
     ModelDecl,

--- a/rustre-parser/src/lexer.rs
+++ b/rustre-parser/src/lexer.rs
@@ -308,6 +308,16 @@ impl rowan::Language for LustreLang {
     }
 }
 
+impl crate::rowan_nom::RowanNomLanguage for LustreLang {
+    fn is_trivia(kind: Self::Kind) -> bool {
+        matches!(kind, Token::Comment | Token::InlineComment | Token::Space)
+    }
+
+    fn get_error_kind() -> Self::Kind {
+        Token::Error
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rustre-parser/src/lib.rs
+++ b/rustre-parser/src/lib.rs
@@ -66,6 +66,8 @@ impl Parse {
     pub fn parse(src: &str) -> Self {
         let lexer = lexer::Token::lexer(src).spanned();
         let tokens: Vec<_> = lexer.map(|(tok, span)| (tok, &src[span])).collect();
-        parser::Parser::parse(tokens)
+        let input = rowan_nom::Input::from(tokens.as_slice());
+        let (_, (root, errors)) = parser::parse_program(input).expect("TODO");
+        Self { root, errors }
     }
 }

--- a/rustre-parser/src/lib.rs
+++ b/rustre-parser/src/lib.rs
@@ -5,7 +5,7 @@ mod rowan_nom;
 
 use std::ops::Range;
 
-use crate::lexer::Token;
+use crate::lexer::{LexerExpansionExt, Token};
 use crate::rowan_nom::RowanNomError;
 use lexer::LustreLang;
 use logos::Logos;
@@ -63,7 +63,7 @@ pub struct Parse {
 
 impl Parse {
     pub fn parse(src: &str) -> Self {
-        let lexer = lexer::Token::lexer(src).spanned();
+        let lexer = Token::lexer(src).spanned().expanded();
         let tokens: Vec<_> = lexer.map(|(tok, span)| (tok, &src[span])).collect();
         let input = rowan_nom::Input::from(tokens.as_slice());
         let (_, (root, errors)) = parser::parse_program(input).expect("TODO");

--- a/rustre-parser/src/lib.rs
+++ b/rustre-parser/src/lib.rs
@@ -6,6 +6,7 @@ mod rowan_nom;
 
 use std::ops::Range;
 
+use crate::lexer::Token;
 use crate::rowan_nom::RowanNomError;
 use lexer::LustreLang;
 use logos::Logos;
@@ -15,6 +16,7 @@ use logos::Logos;
 pub struct Error {
     pub span: Range<usize>,
     pub msg: String,
+    pub cause: Option<Box<Error>>,
 }
 
 impl RowanNomError<LustreLang> for Error {
@@ -22,6 +24,7 @@ impl RowanNomError<LustreLang> for Error {
         Error {
             span: 0..0,
             msg: message.to_string(),
+            cause: None,
         }
     }
 
@@ -29,6 +32,7 @@ impl RowanNomError<LustreLang> for Error {
         Error {
             span: position..position,
             msg: "unexpected eof".to_string(),
+            cause: None,
         }
     }
 
@@ -36,6 +40,15 @@ impl RowanNomError<LustreLang> for Error {
         Error {
             span,
             msg: format!("expected {expected:?}, found {found:?}"),
+            cause: None,
+        }
+    }
+
+    fn with_context(mut self, ctx: &'static str) -> Self {
+        Error {
+            span: self.span.clone(),
+            msg: ctx.to_string(),
+            cause: Some(Box::new(self)),
         }
     }
 }

--- a/rustre-parser/src/lib.rs
+++ b/rustre-parser/src/lib.rs
@@ -70,3 +70,7 @@ impl Parse {
         Self { root, errors }
     }
 }
+
+// TODO: Make these tests opt-in (as well as the rustre_parser_tests_codegen dep)
+#[cfg(test)]
+rustre_parser_tests_codegen::include_lustre_tests!(mod parser_tests);

--- a/rustre-parser/src/lib.rs
+++ b/rustre-parser/src/lib.rs
@@ -17,11 +17,25 @@ pub struct Error {
     pub msg: String,
 }
 
-impl RowanNomError for Error {
+impl RowanNomError<LustreLang> for Error {
     fn from_message(message: &str) -> Self {
         Error {
             span: 0..0,
             msg: message.to_string(),
+        }
+    }
+
+    fn from_unexpected_eof(position: usize) -> Self {
+        Error {
+            span: position..position,
+            msg: "unexpected eof".to_string(),
+        }
+    }
+
+    fn from_unexpected_token(span: Range<usize>, expected: Token, found: Token) -> Self {
+        Error {
+            span,
+            msg: format!("expected {expected:?}, found {found:?}"),
         }
     }
 }

--- a/rustre-parser/src/lib.rs
+++ b/rustre-parser/src/lib.rs
@@ -27,6 +27,22 @@ impl RowanNomError<LustreLang> for Error {
         }
     }
 
+    fn from_expected(position: usize, message: &str) -> Self {
+        Self {
+            span: position..position,
+            msg: message.to_string(),
+            cause: None,
+        }
+    }
+
+    fn from_expected_eof(range: Range<usize>) -> Self {
+        Self {
+            span: range,
+            msg: "expected eof, found token".to_string(),
+            cause: None,
+        }
+    }
+
     fn from_unexpected_eof(position: usize) -> Self {
         Error {
             span: position..position,

--- a/rustre-parser/src/lib.rs
+++ b/rustre-parser/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod ast;
 pub mod lexer;
 pub mod location;
 pub mod parser;

--- a/rustre-parser/src/lib.rs
+++ b/rustre-parser/src/lib.rs
@@ -2,15 +2,28 @@ pub mod ast;
 pub mod lexer;
 pub mod location;
 pub mod parser;
+mod rowan_nom;
 
 use std::ops::Range;
 
+use crate::rowan_nom::RowanNomError;
 use lexer::LustreLang;
 use logos::Logos;
 
+/// TODO remove `Debug`
+#[derive(Debug)]
 pub struct Error {
     pub span: Range<usize>,
     pub msg: String,
+}
+
+impl RowanNomError for Error {
+    fn from_message(message: &str) -> Self {
+        Error {
+            span: 0..0,
+            msg: message.to_string(),
+        }
+    }
 }
 
 pub type SyntaxNode = rowan::SyntaxNode<LustreLang>;
@@ -25,8 +38,7 @@ pub struct Parse {
 impl Parse {
     pub fn parse(src: &str) -> Self {
         let lexer = lexer::Token::lexer(src).spanned();
-        let mut tokens: Vec<_> = lexer.map(|(tok, span)| (tok, &src[span])).collect();
-        tokens.reverse();
+        let tokens: Vec<_> = lexer.map(|(tok, span)| (tok, &src[span])).collect();
         parser::Parser::parse(tokens)
     }
 }

--- a/rustre-parser/src/parser.rs
+++ b/rustre-parser/src/parser.rs
@@ -181,9 +181,13 @@ pub mod merge;
 
 // Ebnf group PredefRules
 
-pub fn parse_predef_op<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    node(
-        PredefOp,
+fn parse_predef_op_t<'slice, 'src: 'slice, P>(
+    mut t: impl FnMut(Token) -> P,
+) -> impl FnMut(Input<'slice, 'src>) -> IResult<'slice, 'src>
+where
+    P: nom::Parser<Input<'slice, 'src>, Children, super::Error>,
+{
+    move |input| {
         alt((
             t(Not),
             t(FBy),
@@ -207,8 +211,12 @@ pub fn parse_predef_op<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'sli
             t(Slash),
             t(Star),
             t(If),
-        )),
-    )(input)
+        ))(input)
+    }
+}
+
+pub fn parse_predef_op<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(PredefOp, parse_predef_op_t(t))(input)
 }
 
 // Ebnf group ExpressionByNamesRules

--- a/rustre-parser/src/parser.rs
+++ b/rustre-parser/src/parser.rs
@@ -236,9 +236,12 @@ fn parse_equation_equals<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'s
         EqualsEquationNode,
         join((
             alt((
-                join((parse_left, expect(t(Equal), "missing `=` in equation"))),
                 join((
-                    expect(parse_left, "missing left operand in equation"),
+                    left::parse_left,
+                    expect(t(Equal), "missing `=` in equation"),
+                )),
+                join((
+                    expect(left::parse_left, "missing left operand in equation"),
                     t(Equal),
                 )),
             )),
@@ -252,64 +255,7 @@ fn parse_equation_equals<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'s
 
 // Ebnf group LeftRules
 
-pub fn parse_left<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    node(
-        LeftNode,
-        alt((
-            many_delimited(success, parse_left_item, t(Comma), peek(t(Equal))),
-            many_delimited(t(OpenPar), parse_left_item, t(Comma), t(ClosePar)),
-        )),
-    )(input)
-}
-
-pub fn parse_left_item<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    fold_many1(
-        parse_id_any,
-        alt((
-            map(join((t(Dot), parse_id_any)), |c| (c, LeftFieldAccessNode)),
-            map(
-                join((
-                    t(OpenBracket),
-                    expect(
-                        alt((expression::parse_expression, parse_select)),
-                        "expected expression or select",
-                    ),
-                    t(CloseBracket),
-                )),
-                |c| (c, LeftTableAccessNode),
-            ),
-        )),
-        |a, (b, n)| (a + b).into_node(n),
-    )(input)
-}
-
-pub fn parse_select<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    node(
-        SelectNode,
-        alt((
-            expression::parse_expression_15,
-            t(CDots),
-            expect(
-                expression::parse_expression_15,
-                "expected second operand in step expression",
-            ),
-            parse_step,
-        )),
-    )(input)
-}
-
-pub fn parse_step<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    opt(node(
-        StepNode,
-        join((
-            t(Step),
-            expect(
-                expression::parse_expression_16,
-                "expected expression after `step`",
-            ),
-        )),
-    ))(input)
-}
+pub mod left;
 
 // Ebnf group ExpressionRules
 

--- a/rustre-parser/src/parser.rs
+++ b/rustre-parser/src/parser.rs
@@ -221,6 +221,8 @@ pub fn parse_predef_op<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'sli
 
 // Ebnf group ExpressionByNamesRules
 
+pub mod expression_by_names;
+
 // Ebnf group ConstantRules
 
 pub fn parse_constant<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {

--- a/rustre-parser/src/parser.rs
+++ b/rustre-parser/src/parser.rs
@@ -102,7 +102,7 @@ pub fn parse_top_level_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult
         constant_decl::parse_const_decl,
         type_decl::parse_type_decl,
         ext_nodes::parse_ext_node_decl,
-        parse_node_decl,
+        nodes::parse_node_decl,
     ))(input)
 }
 
@@ -162,111 +162,6 @@ fn parse_id_any<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'sr
 
 // TODO move everything in there
 pub mod nodes;
-
-/// Parses a (potentially `unsafe`) `node` or `function` declaration
-///
-/// # Tolerated syntax errors
-///
-///   * Omitting the `〈Params〉 returns 〈Params〉` part is only allowed if defining a node alias (when
-///     an `=` sign follows)
-pub fn parse_node_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    node(
-        NodeNode,
-        join((
-            parse_node_type,
-            expect(parse_id_any, "missing function or node name"),
-            static_rules::parse_static_params,
-            opt(parse_params_and_returns),
-            opt(alt((parse_node_decl_definition, parse_node_decl_alias))),
-        )),
-    )(input)
-}
-
-/// Parses `node`, `function`, `unsafe node` and `unsafe function`
-///
-/// This function accepts anything that matches at least one token ; the keyword "`unsafe`" will be
-/// matched even if it isn't followed by `node` or `function`
-pub fn parse_node_type<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    alt((
-        t(Node),
-        t(Function),
-        join((
-            t(Unsafe),
-            expect(
-                alt((t(Node), t(Function))),
-                "expected `node` or `function` after `unsafe`",
-            ),
-        )),
-    ))(input)
-}
-
-/// Loosely parses `〈Params〉 returns 〈Params〉`
-///
-/// Either the first `〈Params〉` or the `returns` token must be present for the parser not to fail.
-fn parse_params_and_returns<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    alt((
-        join((
-            parse_params,
-            expect(t(Returns), "expected `returns` after params"),
-            expect(parse_params, "expected `(params...)` after `returns`"),
-        )),
-        // if the user forgot the first params, we can still attempt to parse using the `returns`
-        // token
-        join((
-            // FIXME: define a parser that immediately fails instead of attempting to parse
-            //        something we already know is missing
-            expect(parse_params, "missing params before `returns`"),
-            t(Returns),
-            expect(parse_params, "expected `(params...)` after `returns`"),
-        )),
-    ))(input)
-}
-
-/// Parses the end of a `NodeDecl`, where a definition is expected
-/// (` [ ; ] 〈LocalDecls〉 〈Body〉 ( . | [ ; ] )`)
-///
-/// # See also
-///
-///   * [`parse_node_decl_alias`].
-///
-/// Both are called by [`parse_node_decl`]
-fn parse_node_decl_definition<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    join((
-        opt(t(Semicolon)),
-        opt(nodes::parse_local_decl_list),
-        parse_body,
-        opt(alt((t(Dot), t(Semicolon)))),
-    ))(input)
-}
-
-/// Parses the end of a `NodeDecl`, where an alias is expected
-/// (` = 〈EffectiveNode〉 [ ; ]`)
-///
-/// # See also
-///
-///   * [`parse_node_decl_definition`].
-///
-/// Both are called by [`parse_node_decl`]
-fn parse_node_decl_alias<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    join((
-        // TODO: unexpect(Semicolon), (eat semicolon but consider it a syntax error)
-        t(Equal),
-        static_rules::parse_effective_node,
-        opt(t(Semicolon)),
-    ))(input)
-}
-
-pub fn parse_params<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    node(
-        ParamsNode,
-        many_delimited(
-            t(OpenPar),
-            nodes::parse_var_decl,
-            t(Comma),
-            join((opt(t(Semicolon)), t(ClosePar))),
-        ),
-    )(input)
-}
 
 // Ebnf group ConstantDeclRules
 

--- a/rustre-parser/src/parser.rs
+++ b/rustre-parser/src/parser.rs
@@ -177,6 +177,8 @@ pub mod expression;
 
 // Ebnf group MergeRules
 
+pub mod merge;
+
 // Ebnf group PredefRules
 
 pub fn parse_predef_op<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {

--- a/rustre-parser/src/parser.rs
+++ b/rustre-parser/src/parser.rs
@@ -101,6 +101,7 @@ pub fn parse_top_level_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult
         parse_include,
         constant_decl::parse_const_decl,
         type_decl::parse_type_decl,
+        ext_nodes::parse_ext_node_decl,
         parse_node_decl,
     ))(input)
 }
@@ -295,6 +296,8 @@ fn parse_type_hat<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, '
 }
 
 // Ebnf group ExtNodesRules
+
+pub mod ext_nodes;
 
 // Ebnf group StaticRules
 

--- a/rustre-parser/src/parser.rs
+++ b/rustre-parser/src/parser.rs
@@ -41,6 +41,9 @@ pub fn many_delimited<'slice, 'src: 'slice, IE: RowanNomError<Lang>>(
                     input = new_input;
                     // TODO: more specific "UnexpectedToken" node below ?
                     children += new_children.into_node(Error);
+
+                    let err = super::Error::from_message("many_preceded is skipping");
+                    children += Children::from_err(err);
                 } else {
                     // TODO: maybe don't error, but consider eof as a RIGHT equivalent + silent error
                     break Err(nom::Err::Error(IE::from_unexpected_eof(input.src_pos())));
@@ -103,12 +106,19 @@ pub fn parse_top_level_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult
         type_decl::parse_type_decl,
         ext_nodes::parse_ext_node_decl,
         nodes::parse_node_decl,
+        model::parse_model_decl,
+        package::parse_pack_decl,
+        package::parse_pack_eq,
     ))(input)
 }
 
 // Ebnf group PackageRules
 
+pub mod package;
+
 // Ebnf group ModelRules
+
+pub mod model;
 
 // Ebnf group IdentRules
 

--- a/rustre-parser/src/parser/body.rs
+++ b/rustre-parser/src/parser/body.rs
@@ -47,7 +47,7 @@ fn parse_equation_equals<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'s
             )),
             expect(
                 expression::parse_expression,
-                "expected at the end of equation",
+                "expected expression at the right of the equation",
             ),
         )),
     )(input)

--- a/rustre-parser/src/parser/body.rs
+++ b/rustre-parser/src/parser/body.rs
@@ -1,0 +1,54 @@
+use super::*;
+
+pub fn parse_body<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        BodyNode,
+        many_delimited(t(Let), parse_equation, success, t(Tel)),
+    )(input)
+}
+
+pub fn parse_equation_list<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    many0(parse_equation)(input)
+}
+
+pub fn parse_equation<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    join((
+        alt((parse_equation_assert, parse_equation_equals)),
+        expect(t(Semicolon), "expected semicolon after equation"),
+    ))(input)
+}
+
+fn parse_equation_assert<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        AssertEquationNode,
+        join((
+            t(Assert),
+            expect(
+                expression::parse_expression,
+                "expected expression after `assert`",
+            ),
+        )),
+    )(input)
+}
+
+fn parse_equation_equals<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        EqualsEquationNode,
+        join((
+            alt((
+                join((
+                    left::parse_left,
+                    expect(t(Equal), "missing `=` in equation"),
+                )),
+                join((
+                    expect(left::parse_left, "missing left operand in equation"),
+                    t(Equal),
+                )),
+            )),
+            expect(
+                expression::parse_expression,
+                "expected at the end of equation",
+            ),
+        )),
+    )(input)
+}

--- a/rustre-parser/src/parser/constant_decl.rs
+++ b/rustre-parser/src/parser/constant_decl.rs
@@ -19,10 +19,13 @@ pub fn parse_one_const_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult
     node(
         OneConstantDeclNode,
         join((
-            parse_lv6_id,
+            ident::parse_lv6_id,
             many0(join((
                 t(Comma),
-                expect(parse_lv6_id, "expected other constant name after `,`"),
+                expect(
+                    ident::parse_lv6_id,
+                    "expected other constant name after `,`",
+                ),
             ))),
             opt(join((
                 t(Colon),

--- a/rustre-parser/src/parser/constant_decl.rs
+++ b/rustre-parser/src/parser/constant_decl.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+pub fn parse_const_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        ConstantDeclNode,
+        join((t(Const), expect(parse_const_decls, "missing constant name"))),
+    )(input)
+}
+
+pub fn parse_const_decls<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    many_delimited(success, parse_one_const_decl, success, peek_neg(t(Ident)))(input)
+}
+
+/// # Tolerated syntax errors
+///
+///   * It shouldn't be possible to specify an initializer on a constant with multiple identifiers,
+///     but the parser accepts it nonetheless
+pub fn parse_one_const_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        OneConstantDeclNode,
+        join((
+            parse_lv6_id,
+            many0(join((
+                t(Comma),
+                expect(parse_lv6_id, "expected other constant name after `,`"),
+            ))),
+            opt(join((
+                t(Colon),
+                expect(parse_type, "unspecified constant type"),
+            ))),
+            opt(join((
+                t(Equal),
+                expect(expression::parse_expression, "missing constant initializer"),
+            ))),
+            expect(t(Semicolon), "expected `;` after const declaration"),
+        )),
+    )(input)
+}

--- a/rustre-parser/src/parser/expression.rs
+++ b/rustre-parser/src/parser/expression.rs
@@ -115,7 +115,7 @@ pub fn parse_expression_terminal<'slice, 'src>(
     expect(
         alt((
             node(ExpressionNode, parse_constant),
-            expr_node(IdentExpressionNode, parse_id_any),
+            expr_node(IdentExpressionNode, ident::parse_id_any),
         )),
         "expected expression",
     )(input)
@@ -342,16 +342,19 @@ pub fn parse_clock_expr<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'sl
         ClockExpressionNode,
         alt((
             join((
-                parse_id_any,
+                ident::parse_id_any,
                 opt(join((
                     t(OpenPar),
-                    expect(parse_id_any, "expected identifier"),
+                    expect(ident::parse_id_any, "expected identifier"),
                     t(ClosePar),
                 ))),
             )),
             join((
                 t(Not),
-                alt((parse_id_any, join((t(OpenPar), parse_id_any, t(ClosePar))))),
+                alt((
+                    ident::parse_id_any,
+                    join((t(OpenPar), ident::parse_id_any, t(ClosePar))),
+                )),
             )),
         )),
     )(input)

--- a/rustre-parser/src/parser/expression.rs
+++ b/rustre-parser/src/parser/expression.rs
@@ -1,0 +1,316 @@
+//! Expression-related parsers
+//!
+//! https://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/lustre-v6/doc/lv6-ref-man.pdf#section.2.10
+
+use super::*;
+
+pub fn expr_node<'slice, 'src: 'slice>(
+    node: Token,
+    parser: impl nom::Parser<Input<'slice, 'src>, Children, RustreParseError>,
+) -> impl FnMut(Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    super::node(ExpressionNode, super::node(node, parser))
+}
+
+macro_rules! parse_ops {
+    ($operator:ident => $operator_node:ident) => {
+        ::nom::Parser::map(t(Token::$operator), |c| (c, Token::$operator_node))
+    };
+    {$($operator:ident => $operator_node:ident,)*} => {
+        alt((
+            $(parse_ops!($operator => $operator_node),
+            )*
+        ))
+    };
+}
+
+fn parse_expression_unary<'slice, 'src: 'slice>(
+    operator: Token,
+    operator_node: Token,
+    mut next: impl nom::Parser<Input<'slice, 'src>, Children, RustreParseError>,
+) -> impl FnMut(Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    move |input| expr_node(operator_node, join((t(operator), |i| next.parse(i))))(input)
+}
+
+/// Parses a binary left-associative chain of expression
+fn parse_expression_left<'slice, 'src: 'slice>(
+    mut parse_operator: impl nom::Parser<Input<'slice, 'src>, (Children, Token), RustreParseError>,
+    mut next: impl nom::Parser<Input<'slice, 'src>, Children, RustreParseError> + Copy,
+) -> impl FnMut(Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    move |input| {
+        fold_many1(
+            next,
+            |input| {
+                let (input, (a, n)) = parse_operator.parse(input)?;
+                let (input, b) = next.parse(input)?;
+                Ok((input, (a + b, n)))
+            },
+            |a, (b, n)| (a + b).into_node(n).into_node(ExpressionNode),
+        )(input)
+    }
+}
+
+/// Parses a binary right-associative chain of expression
+fn parse_expression_right<'slice, 'src: 'slice>(
+    mut parse_operator: impl nom::Parser<Input<'slice, 'src>, (Children, Token), RustreParseError>,
+    mut next: impl nom::Parser<Input<'slice, 'src>, Children, RustreParseError> + Copy,
+) -> impl FnMut(Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    move |input| {
+        let next2 = next;
+
+        fold_many1_right(
+            |input| {
+                let (input, a) = next.parse(input)?;
+                let (input, (b, n)) = parse_operator.parse(input)?;
+                Ok((input, (a + b, n)))
+            },
+            next2,
+            |a, (b, n)| (a + b).into_node(n).into_node(ExpressionNode),
+        )(input)
+    }
+}
+
+/// Parses a binary non-associative expression, or just one operand
+///
+/// # Tolerated syntax errors
+///
+///   * There may actually be more than two operands, but they should be treated as errors as
+///     non-associativity in lustre disallows their chaining
+fn parse_expression_no_assoc<'slice, 'src: 'slice>(
+    mut parse_operator: impl nom::Parser<Input<'slice, 'src>, (Children, Token), RustreParseError>,
+    mut next: impl nom::Parser<Input<'slice, 'src>, Children, RustreParseError>,
+) -> impl FnMut(Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    move |input| {
+        let (mut input, mut left_expr) = next.parse(input)?;
+
+        if let Ok((new_input, (operator, operator_node))) = parse_operator.parse(input.clone()) {
+            input = new_input;
+            left_expr += operator;
+
+            let (new_input, operand) = next.parse(input)?;
+            input = new_input;
+            left_expr += operand;
+
+            left_expr = left_expr.into_node(operator_node).into_node(ExpressionNode);
+        }
+
+        // Tolerance: Handle additional occurrences of the operator
+        // FIXME: we should emit an error too
+        while let Ok((new_input, (mut operator, _))) = parse_operator.parse(input.clone()) {
+            input = new_input;
+
+            let (new_input, operand) = next.parse(input)?;
+            input = new_input;
+            operator += operand;
+
+            left_expr += operator.into_node(Error);
+        }
+
+        Ok((input, left_expr))
+    }
+}
+
+pub fn parse_expression_terminal<'slice, 'src>(
+    input: Input<'slice, 'src>,
+) -> IResult<'slice, 'src> {
+    expect(
+        alt((
+            node(ExpressionNode, parse_constant),
+            expr_node(IdentExpressionNode, parse_id_any),
+        )),
+        "expected expression",
+    )(input)
+}
+
+// This one doesn't really exist but it is never mentioned in the spec
+pub fn parse_expression_0<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    fold_many1(
+        parse_expression_terminal,
+        alt((
+            map(parse_expression_list_par, |c| (c, CallByPosExpressionNode)),
+            map(parse_array_brackets, |c| (c, ArrayAccessExpressionNode)),
+        )),
+        |a, (b, n)| (a + b).into_node(n).into_node(ExpressionNode),
+    )(input)
+}
+
+pub fn parse_expression_1<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    parse_expression_right(parse_ops!(FBy => FbyExpressionNode), parse_expression_0)(input)
+}
+
+pub use parse_expression_1 as parse_expression_2; // TODO
+
+pub fn parse_expression_3<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    alt((
+        expr_node(ParExpressionNode, parse_expression_list_par),
+        parse_expression_2,
+    ))(input)
+}
+
+pub fn parse_expression_4<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    parse_expression_left(
+        parse_ops! {
+            Hat => HatExpressionNode,
+            Dot => FieldAccessExpressionNode,
+        },
+        parse_expression_3,
+    )(input)
+}
+
+pub fn parse_expression_5<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    alt((
+        parse_expression_unary(Minus, NegExpressionNode, parse_expression_5),
+        parse_expression_unary(Pre, PreExpressionNode, parse_expression_5),
+        parse_expression_unary(Current, CurrentExpressionNode, parse_expression_5),
+        parse_expression_unary(Current, CurrentExpressionNode, parse_expression_5),
+        expr_node(
+            DieseExpressionNode,
+            join((
+                t(Diese),
+                expect(
+                    many_delimited(t(OpenPar), parse_expression, t(Comma), t(ClosePar)),
+                    "expected parenthesis-delimited expression after `#`",
+                ),
+            )),
+        ),
+        expr_node(
+            NorExpressionNode,
+            join((
+                t(Nor),
+                expect(
+                    many_delimited(t(OpenPar), parse_expression, t(Comma), t(ClosePar)),
+                    "expected parenthesis-delimited expression after `nor`",
+                ),
+            )),
+        ),
+        parse_expression_4,
+    ))(input)
+}
+
+pub fn parse_expression_6<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    alt((
+        parse_expression_unary(Int, IntExpressionNode, parse_expression_6),
+        parse_expression_unary(Real, RealExpressionNode, parse_expression_6),
+        parse_expression_5,
+    ))(input)
+}
+
+pub fn parse_expression_7<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    parse_expression_left(parse_ops!(When => WhenExpressionNode), parse_expression_6)(input)
+}
+
+pub fn parse_expression_8<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    parse_expression_left(parse_ops!(Power => PowerExpressionNode), parse_expression_7)(input)
+}
+
+pub fn parse_expression_9<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    parse_expression_left(
+        parse_ops! {
+            Star => MulExpressionNode,
+            Slash => DivExpressionNode,
+            Div => DivExpressionNode,
+            Percent => ModExpressionNode,
+            Mod => ModExpressionNode,
+        },
+        parse_expression_8,
+    )(input)
+}
+
+pub fn parse_expression_10<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    parse_expression_left(
+        parse_ops! {
+            Plus => AddExpressionNode,
+            Minus => SubExpressionNode,
+        },
+        parse_expression_9,
+    )(input)
+}
+
+pub fn parse_expression_11<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    alt((
+        parse_expression_unary(Not, NotExpressionNode, parse_expression_11),
+        parse_expression_10,
+    ))(input)
+}
+
+pub fn parse_expression_12<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    parse_expression_no_assoc(
+        parse_ops! {
+            Lt => LtExpressionNode,
+            Lte => LtExpressionNode,
+            Equal => EqExpressionNode,
+            Gt => GtExpressionNode,
+            Gte => GtExpressionNode,
+            Neq => NeqExpressionNode,
+        },
+        parse_expression_11,
+    )(input)
+}
+
+pub fn parse_expression_13<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    parse_expression_left(parse_ops!(And => AndExpressionNode), parse_expression_12)(input)
+}
+
+pub fn parse_expression_14<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    parse_expression_left(
+        parse_ops! {
+            Or => OrExpressionNode,
+            Xor => XorExpressionNode,
+        },
+        parse_expression_13,
+    )(input)
+}
+
+pub fn parse_expression_15<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    parse_expression_right(parse_ops!(Impl => ImplExpressionNode), parse_expression_14)(input)
+}
+
+pub use parse_expression_15 as parse_expression_16;
+pub use parse_expression_16 as parse_expression_17;
+
+pub fn parse_expression_18<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    parse_expression_left(
+        parse_ops!(Arrow => ArrowExpressionNode),
+        parse_expression_17,
+    )(input)
+}
+
+pub fn parse_expression_19<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    parse_expression_left(parse_ops!(Bar => ConcatExpressionNode), parse_expression_18)(input)
+}
+
+pub fn parse_expression_20<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    alt((
+        expr_node(
+            IfExpressionNode,
+            // TODO check associativity compliance of `if then else`
+            join((
+                t(If),
+                parse_expression_20,
+                t(Then),
+                parse_expression_20,
+                t(Else),
+                parse_expression_20,
+            )),
+        ),
+        parse_expression_19,
+    ))(input)
+}
+
+pub fn parse_expression<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    parse_expression_20(input)
+}
+
+pub fn parse_expression_list<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    many_delimited(success, parse_expression, t(Comma), success)(input)
+}
+
+pub fn parse_expression_list_par<'slice, 'src>(
+    input: Input<'slice, 'src>,
+) -> IResult<'slice, 'src> {
+    many_delimited(t(OpenPar), parse_expression, t(Comma), t(ClosePar))(input)
+}
+
+fn parse_array_brackets<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    // TODO select
+    join((t(OpenBracket), parse_expression, t(CloseBracket)))(input)
+}

--- a/rustre-parser/src/parser/expression.rs
+++ b/rustre-parser/src/parser/expression.rs
@@ -330,8 +330,11 @@ fn parse_call_par<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, '
 }
 
 fn parse_array_brackets<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    // TODO select
-    join((t(OpenBracket), parse_expression, t(CloseBracket)))(input)
+    join((
+        t(OpenBracket),
+        alt((left::parse_select, parse_expression)),
+        t(CloseBracket),
+    ))(input)
 }
 
 pub fn parse_clock_expr<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {

--- a/rustre-parser/src/parser/expression.rs
+++ b/rustre-parser/src/parser/expression.rs
@@ -112,13 +112,10 @@ fn parse_expression_no_assoc<'slice, 'src: 'slice>(
 pub fn parse_expression_terminal<'slice, 'src>(
     input: Input<'slice, 'src>,
 ) -> IResult<'slice, 'src> {
-    expect(
-        alt((
-            node(ExpressionNode, parse_constant),
-            expr_node(IdentExpressionNode, ident::parse_id_any),
-        )),
-        "expected expression",
-    )(input)
+    alt((
+        node(ExpressionNode, parse_constant),
+        expr_node(IdentExpressionNode, ident::parse_id_any),
+    ))(input)
 }
 
 // This one doesn't really exist but it is never mentioned in the spec
@@ -142,6 +139,7 @@ pub use parse_expression_1 as parse_expression_2; // TODO
 pub fn parse_expression_3<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
     alt((
         expr_node(ParExpressionNode, parse_expression_list_par),
+        expr_node(ArrayLiteralExpressionNode, parse_expression_list_bracket),
         parse_expression_2,
     ))(input)
 }
@@ -320,6 +318,12 @@ pub fn parse_expression_list_par<'slice, 'src>(
     input: Input<'slice, 'src>,
 ) -> IResult<'slice, 'src> {
     many_delimited(t(OpenPar), parse_expression, t(Comma), t(ClosePar))(input)
+}
+
+pub fn parse_expression_list_bracket<'slice, 'src>(
+    input: Input<'slice, 'src>,
+) -> IResult<'slice, 'src> {
+    many_delimited(t(OpenBracket), parse_expression, t(Comma), t(CloseBracket))(input)
 }
 
 fn parse_call_par<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {

--- a/rustre-parser/src/parser/expression.rs
+++ b/rustre-parser/src/parser/expression.rs
@@ -338,8 +338,11 @@ fn parse_call_par<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, '
 fn parse_array_brackets<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
     join((
         t(OpenBracket),
-        alt((left::parse_select, parse_expression)),
-        t(CloseBracket),
+        expect(
+            alt((left::parse_select, parse_expression)),
+            "expected expression",
+        ),
+        expect(t(CloseBracket), "expected closing square bracket"),
     ))(input)
 }
 

--- a/rustre-parser/src/parser/expression.rs
+++ b/rustre-parser/src/parser/expression.rs
@@ -115,6 +115,14 @@ pub fn parse_expression_terminal<'slice, 'src>(
     alt((
         node(ExpressionNode, parse_constant),
         expr_node(IdentExpressionNode, ident::parse_id_any),
+        expr_node(
+            MergeExpressionNode,
+            join((
+                t(Merge),
+                expect(ident::parse_id_any, "expected identifier"),
+                merge::parse_merge_cases,
+            )),
+        ),
     ))(input)
 }
 

--- a/rustre-parser/src/parser/expression.rs
+++ b/rustre-parser/src/parser/expression.rs
@@ -108,6 +108,7 @@ pub fn parse_expression_terminal<'slice, 'src>(
 ) -> IResult<'slice, 'src> {
     alt((
         node(ExpressionNode, parse_constant),
+        expression_by_names::parse_call_by_name_expression,
         expr_node(IdentExpressionNode, ident::parse_id_any),
         expr_node(
             MergeExpressionNode,

--- a/rustre-parser/src/parser/expression_by_names.rs
+++ b/rustre-parser/src/parser/expression_by_names.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+pub fn parse_call_by_name_expression<'slice, 'src>(
+    input: Input<'slice, 'src>,
+) -> IResult<'slice, 'src> {
+    expression::expr_node(
+        CallByNameExpressionNode,
+        join((
+            ident::parse_id_any,
+            many_delimited(
+                join((
+                    t(OpenBrace),
+                    opt(join((
+                        expect(ident::parse_id_any, "expected ident before `with`"),
+                        t(With),
+                    ))),
+                )),
+                parse_call_by_name_param,
+                alt((t(Semicolon), t(Comma))),
+                join((opt(t(Semicolon)), t(CloseBrace))),
+            ),
+        )),
+    )(input)
+}
+
+pub fn parse_call_by_name_param<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        CallByNameParamNode,
+        alt((
+            join((
+                ident::parse_id_any,
+                expect(
+                    join((t(Equal), expression::parse_expression)),
+                    "expected `= <value>` after field name",
+                ),
+            )),
+            join((
+                expect(ident::parse_id_any, "expected field name"),
+                t(Equal),
+                expect(expression::parse_expression, "expected value"),
+            )),
+        )),
+    )(input)
+}

--- a/rustre-parser/src/parser/ext_nodes.rs
+++ b/rustre-parser/src/parser/ext_nodes.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+/// Parses `extern node`, `extern function`, `unsafe extern node` and `unsafe extern function`
+///
+/// This function accepts anything that matches at least one token ; the keyword "`unsafe`" will be
+/// matched even if it isn't followed by `node` or `function`
+fn parse_ext_node_type<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    join((
+        opt(t(Unsafe)),
+        t(Extern),
+        expect(
+            alt((t(Node), t(Function))),
+            "expected `node` or `function` after `extern`",
+        ),
+    ))(input)
+}
+
+pub fn parse_ext_node_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        ExternalNodeDeclNode,
+        join((
+            parse_ext_node_type,
+            expect(parse_id_any, "missing external node name"),
+            expect(
+                parse_params_and_returns,
+                "missing signature (params and returned values)",
+            ),
+            opt(t(Semicolon)),
+        )),
+    )(input)
+}

--- a/rustre-parser/src/parser/ext_nodes.rs
+++ b/rustre-parser/src/parser/ext_nodes.rs
@@ -22,7 +22,7 @@ pub fn parse_ext_node_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<
             parse_ext_node_type,
             expect(parse_id_any, "missing external node name"),
             expect(
-                parse_params_and_returns,
+                nodes::parse_params_and_returns,
                 "missing signature (params and returned values)",
             ),
             opt(t(Semicolon)),

--- a/rustre-parser/src/parser/ext_nodes.rs
+++ b/rustre-parser/src/parser/ext_nodes.rs
@@ -20,7 +20,7 @@ pub fn parse_ext_node_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<
         ExternalNodeDeclNode,
         join((
             parse_ext_node_type,
-            expect(parse_id_any, "missing external node name"),
+            expect(ident::parse_id_any, "missing external node name"),
             expect(
                 nodes::parse_params_and_returns,
                 "missing signature (params and returned values)",

--- a/rustre-parser/src/parser/ident.rs
+++ b/rustre-parser/src/parser/ident.rs
@@ -1,0 +1,47 @@
+use super::*;
+
+pub fn parse_lv6_id_ref<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    join((
+        t(Ident),
+        opt(join((
+            t_raw(DoubleColon),
+            expect(t_raw(Ident), "expected ident after colon"),
+        ))),
+    ))(input)
+}
+
+pub fn parse_lv6_id<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    join((parse_lv6_id_ref, opt(parse_pragma)))(input)
+}
+
+pub fn parse_pragma<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        PragmaNode,
+        join((t(Percent), t(Ident), t(Colon), t(Ident), t(Percent))),
+    )(input)
+}
+
+/// Parses an Lv6Id or an Lv6IdRef wrapped in an [`IdNode`], with an optional pragma
+///
+/// This parser should be used when parsing any ID, even when only one of the two types should
+/// actually be used. This makes the parser more lax and allows for better diagnostics.
+///
+/// # Tolerated syntax errors
+///
+///   * Pragma after Lv6IdRef, when it should only occur after an Lv6Id
+///   * This parser is supposed to be called every time an Lv6Id or Lv6IdRef is expected, even if
+///     only one of those is actually valid
+#[rustfmt::skip]
+pub fn parse_id_any<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        IdNode,
+        join((
+            t(Ident),
+            opt(join((
+                t_raw(DoubleColon),
+                expect(t_raw(Ident), "expected ident after colon"),
+            ))),
+            opt(parse_pragma),
+        )),
+    )(input)
+}

--- a/rustre-parser/src/parser/ident.rs
+++ b/rustre-parser/src/parser/ident.rs
@@ -39,7 +39,7 @@ pub fn parse_id_any<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice,
             t(Ident),
             opt(join((
                 t_raw(DoubleColon),
-                expect(t_raw(Ident), "expected ident after colon"),
+                expect(alt((t_raw(Ident), parse_predef_op_t(t_raw))), "expected ident after colon"),
             ))),
             opt(parse_pragma),
         )),

--- a/rustre-parser/src/parser/left.rs
+++ b/rustre-parser/src/parser/left.rs
@@ -12,9 +12,11 @@ pub fn parse_left<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, '
 
 pub fn parse_left_item<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
     fold_many1(
-        parse_id_any,
+        ident::parse_id_any,
         alt((
-            map(join((t(Dot), parse_id_any)), |c| (c, LeftFieldAccessNode)),
+            map(join((t(Dot), ident::parse_id_any)), |c| {
+                (c, LeftFieldAccessNode)
+            }),
             map(
                 join((
                     t(OpenBracket),

--- a/rustre-parser/src/parser/left.rs
+++ b/rustre-parser/src/parser/left.rs
@@ -1,0 +1,60 @@
+use super::*;
+
+pub fn parse_left<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        LeftNode,
+        alt((
+            many_delimited(success, parse_left_item, t(Comma), peek(t(Equal))),
+            many_delimited(t(OpenPar), parse_left_item, t(Comma), t(ClosePar)),
+        )),
+    )(input)
+}
+
+pub fn parse_left_item<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    fold_many1(
+        parse_id_any,
+        alt((
+            map(join((t(Dot), parse_id_any)), |c| (c, LeftFieldAccessNode)),
+            map(
+                join((
+                    t(OpenBracket),
+                    expect(
+                        alt((expression::parse_expression, parse_select)),
+                        "expected expression or select",
+                    ),
+                    t(CloseBracket),
+                )),
+                |c| (c, LeftTableAccessNode),
+            ),
+        )),
+        |a, (b, n)| (a + b).into_node(n),
+    )(input)
+}
+
+pub fn parse_select<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        SelectNode,
+        alt((
+            expression::parse_expression_15,
+            t(CDots),
+            expect(
+                expression::parse_expression_15,
+                "expected second operand in step expression",
+            ),
+            parse_step,
+        )),
+    )(input)
+}
+
+pub fn parse_step<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    opt(node(
+        StepNode,
+        join((
+            t(Step),
+            expect(
+                expression::parse_expression_16,
+                "expected expression after `step`",
+            ),
+        )),
+    ))(input)
+}

--- a/rustre-parser/src/parser/left.rs
+++ b/rustre-parser/src/parser/left.rs
@@ -4,8 +4,8 @@ pub fn parse_left<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, '
     node(
         LeftNode,
         alt((
-            many_delimited(success, parse_left_item, t(Comma), peek(t(Equal))),
             many_delimited(t(OpenPar), parse_left_item, t(Comma), t(ClosePar)),
+            many_delimited(success, parse_left_item, t(Comma), peek(t(Equal))),
         )),
     )(input)
 }

--- a/rustre-parser/src/parser/left.rs
+++ b/rustre-parser/src/parser/left.rs
@@ -18,14 +18,15 @@ pub fn parse_left_item<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'sli
                 (c, LeftFieldAccessNode)
             }),
             map(
-                join((
+                many_delimited(
                     t(OpenBracket),
                     expect(
-                        alt((expression::parse_expression, parse_select)),
+                        alt((parse_select, expression::parse_expression)),
                         "expected expression or select",
                     ),
+                    eof,
                     t(CloseBracket),
-                )),
+                ),
                 |c| (c, LeftTableAccessNode),
             ),
         )),

--- a/rustre-parser/src/parser/left.rs
+++ b/rustre-parser/src/parser/left.rs
@@ -36,7 +36,7 @@ pub fn parse_left_item<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'sli
 pub fn parse_select<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
     node(
         SelectNode,
-        alt((
+        join((
             expression::parse_expression_15,
             t(CDots),
             expect(

--- a/rustre-parser/src/parser/merge.rs
+++ b/rustre-parser/src/parser/merge.rs
@@ -1,0 +1,18 @@
+use super::*;
+
+pub fn parse_merge_cases<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    many0(parse_merge_case)(input)
+}
+
+pub fn parse_merge_case<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        MergeCaseNode,
+        join((
+            t(OpenPar),
+            alt((t(True), t(False), ident::parse_id_any)),
+            t(Arrow),
+            expression::parse_expression,
+            t(ClosePar),
+        )),
+    )(input)
+}

--- a/rustre-parser/src/parser/model.rs
+++ b/rustre-parser/src/parser/model.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+pub fn parse_provides<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    opt(many_delimited(
+        t(Provides),
+        join((
+            parse_provide,
+            expect(t(Semicolon), "provides must be separated by semicolons"),
+        )),
+        success,
+        peek(t(Body)),
+    ))(input)
+}
+
+pub fn parse_provide<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        ProvidesNode,
+        alt((
+            join((
+                t(Const),
+                expect(
+                    join((t(Colon), expect(parse_type, "missing type after `:`"))),
+                    "type of constant must be specified explicitly",
+                ),
+                opt(join((
+                    t(Equal),
+                    expect(
+                        expression::parse_expression,
+                        "expected expression initializer after `=`",
+                    ),
+                ))),
+            )),
+            join((
+                nodes::parse_node_type,
+                expect(ident::parse_id_any, "missing node name"),
+                static_rules::parse_static_params,
+                expect(nodes::parse_params_and_returns, "missing node signature"),
+            )),
+            join((
+                t(Type),
+                expect(type_decl::parse_one_type_decl, "expected type declaration"),
+            )),
+        )),
+    )(input)
+}
+
+pub fn parse_model_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        ModelDeclNode,
+        join((
+            t(Model),
+            expect(ident::parse_id_any, "missing model name"),
+            package::parse_uses,
+            expect(
+                many_delimited(
+                    t(Needs),
+                    static_rules::parse_static_param,
+                    t(Semicolon),
+                    join((t(Semicolon), peek(alt((t(Provides), t(Body)))))),
+                ),
+                "expected `needs` clause",
+            ),
+            parse_provides,
+            package::parse_pack_decl_body,
+        )),
+    )(input)
+}

--- a/rustre-parser/src/parser/model.rs
+++ b/rustre-parser/src/parser/model.rs
@@ -18,6 +18,7 @@ pub fn parse_provide<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice
         alt((
             join((
                 t(Const),
+                expect(ident::parse_id_any, "missing const name"),
                 expect(
                     join((t(Colon), expect(parse_type, "missing type after `:`"))),
                     "type of constant must be specified explicitly",

--- a/rustre-parser/src/parser/nodes.rs
+++ b/rustre-parser/src/parser/nodes.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+pub fn parse_typed_lv6_ids<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        TypedLv6IdsNode,
+        join((
+            parse_lv6_id,
+            many0(join((
+                t(Comma),
+                expect(parse_lv6_id, "expected another identifier after `,`"),
+            ))),
+            expect(
+                join((t(Colon), expect(parse_type, "missing type expression"))),
+                "type must be specified explicitly",
+            ),
+        )),
+    )(input)
+}
+
+pub fn parse_typed_valued_lv6_id<'slice, 'src>(
+    input: Input<'slice, 'src>,
+) -> IResult<'slice, 'src> {
+    node(
+        TypedValuedLv6IdNode,
+        join((
+            parse_lv6_id,
+            many0(join((
+                t(Comma),
+                expect(parse_lv6_id, "expected other field name after `,`"),
+            ))),
+            opt(join((
+                t(Colon),
+                expect(parse_type, "unspecified struct field type"),
+            ))),
+            opt(join((
+                t(Equal),
+                expect(expression::parse_expression, "missing field initializer"),
+            ))),
+        )),
+    )(input)
+}
+
+pub fn parse_local_decl_list<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    join((parse_one_local_decl, many0(parse_one_local_decl)))(input)
+}
+
+pub fn parse_one_local_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    alt((parse_local_consts, parse_local_vars))(input)
+}
+
+pub fn parse_local_consts<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    join((
+        t(Const),
+        expect(
+            constant_decl::parse_const_decls,
+            "missing constant declaration",
+        ),
+    ))(input)
+}
+
+pub fn parse_local_vars<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    many_delimited(t(Var), parse_var_decl, t(Semicolon), t(Semicolon))(input)
+}
+
+pub fn parse_var_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    alt((
+        join((parse_typed_lv6_ids, opt(join((
+            t(When),
+            expect(expression::parse_clock_expr, "expected clock expression"),
+        ))))),
+        join((
+            many_delimited(t(OpenPar), parse_typed_lv6_ids, t(Semicolon), t(ClosePar)),
+            expect(t(When), "expected `when` to complete clock expression, remove previous parenthesis if you didn't mean to start a clock expression"),
+            expect(expression::parse_clock_expr, "expected clock expression"),
+        )),
+    ))(input)
+}

--- a/rustre-parser/src/parser/nodes.rs
+++ b/rustre-parser/src/parser/nodes.rs
@@ -139,7 +139,7 @@ pub fn parse_params<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice,
         many_delimited(
             t(OpenPar),
             nodes::parse_var_decl,
-            t(Comma),
+            t(Semicolon),
             join((opt(t(Semicolon)), t(ClosePar))),
         ),
     )(input)

--- a/rustre-parser/src/parser/nodes.rs
+++ b/rustre-parser/src/parser/nodes.rs
@@ -4,10 +4,10 @@ pub fn parse_typed_lv6_ids<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<
     node(
         TypedLv6IdsNode,
         join((
-            parse_lv6_id,
+            ident::parse_lv6_id,
             many0(join((
                 t(Comma),
-                expect(parse_lv6_id, "expected another identifier after `,`"),
+                expect(ident::parse_lv6_id, "expected another identifier after `,`"),
             ))),
             expect(
                 join((t(Colon), expect(parse_type, "missing type expression"))),
@@ -23,10 +23,10 @@ pub fn parse_typed_valued_lv6_id<'slice, 'src>(
     node(
         TypedValuedLv6IdNode,
         join((
-            parse_lv6_id,
+            ident::parse_lv6_id,
             many0(join((
                 t(Comma),
-                expect(parse_lv6_id, "expected other field name after `,`"),
+                expect(ident::parse_lv6_id, "expected other field name after `,`"),
             ))),
             opt(join((
                 t(Colon),
@@ -51,7 +51,7 @@ pub fn parse_node_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'sli
         NodeNode,
         join((
             parse_node_type,
-            expect(parse_id_any, "missing function or node name"),
+            expect(ident::parse_id_any, "missing function or node name"),
             static_rules::parse_static_params,
             opt(parse_params_and_returns),
             opt(alt((parse_node_decl_definition, parse_node_decl_alias))),
@@ -111,7 +111,7 @@ fn parse_node_decl_definition<'slice, 'src>(input: Input<'slice, 'src>) -> IResu
     join((
         opt(t(Semicolon)),
         opt(nodes::parse_local_decl_list),
-        parse_body,
+        body::parse_body,
         opt(alt((t(Dot), t(Semicolon)))),
     ))(input)
 }

--- a/rustre-parser/src/parser/package.rs
+++ b/rustre-parser/src/parser/package.rs
@@ -16,10 +16,13 @@ pub fn parse_pack_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'sli
 pub fn parse_pack_decl_body<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
     node(
         PackageDeclBody,
-        expect(
-            many_delimited(t(Body), parse_top_level_decl, success, t(End)),
-            "missing package body (`body` ... `end`)",
-        ),
+        join((
+            t(Body),
+            expect(
+                many_delimited(success, parse_top_level_decl, success, t(End)),
+                "missing package body (`body` ... `end`)",
+            ),
+        )),
     )(input)
 }
 

--- a/rustre-parser/src/parser/package.rs
+++ b/rustre-parser/src/parser/package.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+pub fn parse_pack_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        PackageDeclNode,
+        join((
+            t(Package),
+            expect(ident::parse_id_any, "missing package name"),
+            parse_uses,
+            model::parse_provides,
+            parse_pack_decl_body,
+        )),
+    )(input)
+}
+
+pub fn parse_pack_decl_body<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        PackageDeclBody,
+        expect(
+            many_delimited(t(Body), parse_top_level_decl, success, t(End)),
+            "missing package body (`body` ... `end`)",
+        ),
+    )(input)
+}
+
+pub fn parse_uses<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    opt(node(
+        UsesNode,
+        many_delimited(
+            t(Uses),
+            expect(ident::parse_id_any, "missing use name"),
+            t(Comma),
+            t(Semicolon),
+        ),
+    ))(input)
+}
+
+pub fn parse_eq_or_is<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    alt((t(Equal), t(Is)))(input)
+}
+
+pub fn parse_pack_eq<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        PackageAliasNode,
+        join((
+            t(Package),
+            expect(ident::parse_id_any, "missing package alias name"),
+            parse_eq_or_is,
+            expect(ident::parse_id_any, "missing aliased package name"),
+            expect(
+                node(
+                    NamedStaticArgsNode,
+                    many_delimited(
+                        t(OpenPar),
+                        static_rules::parse_named_static_arg,
+                        alt((t(Comma), t(Semicolon))),
+                        t(ClosePar),
+                    ),
+                ),
+                "expected `();` to complete package alias",
+            ),
+            expect(t(Semicolon), "expected `;` to complete package alias"),
+        )),
+    )(input)
+}

--- a/rustre-parser/src/parser/static_rules.rs
+++ b/rustre-parser/src/parser/static_rules.rs
@@ -26,12 +26,12 @@ pub fn parse_static_param<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'
                 ),
             )),
             join((
-                parse_node_type,
+                nodes::parse_node_type,
                 expect(
                     join((
                         parse_id_any,
                         expect(
-                            parse_params_and_returns,
+                            nodes::parse_params_and_returns,
                             "signature must include params and return values",
                         ),
                     )),

--- a/rustre-parser/src/parser/static_rules.rs
+++ b/rustre-parser/src/parser/static_rules.rs
@@ -87,18 +87,6 @@ pub fn parse_static_arg<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'sl
     )(input)
 }
 
-pub fn parse_named_static_args<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    node(
-        NamedStaticArgsNode,
-        many_delimited(
-            t(OpenStaticPar),
-            parse_named_static_arg,
-            alt((t(Comma), t(Semicolon))),
-            t(CloseStaticPar),
-        ),
-    )(input)
-}
-
 pub fn parse_named_static_arg<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
     node(NamedStaticArgNode, t(todo!()))(input)
 }

--- a/rustre-parser/src/parser/static_rules.rs
+++ b/rustre-parser/src/parser/static_rules.rs
@@ -77,7 +77,7 @@ pub fn parse_static_arg<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'sl
                 alt((t(Node), t(Function))),
                 expect(parse_effective_node, "expected node"),
             )),
-            parse_predef_op,
+            join((parse_predef_op, peek(alt((t(Comma), t(Semicolon)))))),
             parse_surely_node,
             parse_surely_type,
             // TODO: check if that works, normally it's a SimpleExp but I guess we can verify the

--- a/rustre-parser/src/parser/static_rules.rs
+++ b/rustre-parser/src/parser/static_rules.rs
@@ -1,0 +1,112 @@
+use super::*;
+
+pub fn parse_static_params<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    opt(node(
+        StaticParamsNode,
+        many_delimited(
+            t(OpenStaticPar),
+            parse_static_param,
+            t(Semicolon),
+            t(CloseStaticPar),
+        ),
+    ))(input)
+}
+
+pub fn parse_static_param<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        StaticParamNode,
+        alt((
+            join((t(Type), expect(parse_id_any, "expected id after `type`"))),
+            join((
+                t(Const),
+                expect(parse_id_any, "expected id after `const`"),
+                expect(
+                    join((t(Colon), expect(parse_type, "expected type after colon"))),
+                    "const static param must specify a type",
+                ),
+            )),
+            join((
+                parse_node_type,
+                expect(
+                    join((
+                        parse_id_any,
+                        expect(
+                            parse_params_and_returns,
+                            "signature must include params and return values",
+                        ),
+                    )),
+                    "unterminated node signature",
+                ),
+            )),
+        )),
+    )(input)
+}
+
+pub fn parse_effective_node<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        EffectiveNodeNode,
+        join((parse_id_any, opt(parse_static_args))),
+    )(input)
+}
+
+pub fn parse_static_args<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        StaticArgsNode,
+        many_delimited(
+            t(OpenStaticPar),
+            parse_static_arg,
+            alt((t(Comma), t(Semicolon))),
+            t(CloseStaticPar),
+        ),
+    )(input)
+}
+
+pub fn parse_static_arg<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        StaticArgNode,
+        alt((
+            join((t(Type), expect(parse_type, "expected type"))),
+            join((
+                t(Const),
+                expect(expression::parse_expression, "expected expression"),
+            )),
+            join((
+                alt((t(Node), t(Function))),
+                expect(parse_effective_node, "expected node"),
+            )),
+            parse_predef_op,
+            parse_surely_node,
+            parse_surely_type,
+            // TODO: check if that works, normally it's a SimpleExp but I guess we can verify the
+            //       simpleness of the expression at post-parsing time
+            expression::parse_expression,
+        )),
+    )(input)
+}
+
+pub fn parse_named_static_args<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        NamedStaticArgsNode,
+        many_delimited(
+            t(OpenStaticPar),
+            parse_named_static_arg,
+            alt((t(Comma), t(Semicolon))),
+            t(CloseStaticPar),
+        ),
+    )(input)
+}
+
+pub fn parse_named_static_arg<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(NamedStaticArgNode, t(todo!()))(input)
+}
+
+pub fn parse_surely_node<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(EffectiveNodeNode, join((parse_id_any, parse_static_args)))(input)
+}
+
+pub fn parse_surely_type<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        TypeNode,
+        join((alt((t(Bool), t(Int), t(Real))), parse_type_hat)),
+    )(input)
+}

--- a/rustre-parser/src/parser/static_rules.rs
+++ b/rustre-parser/src/parser/static_rules.rs
@@ -88,7 +88,37 @@ pub fn parse_static_arg<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'sl
 }
 
 pub fn parse_named_static_arg<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    node(NamedStaticArgNode, t(todo!()))(input)
+    node(
+        NamedStaticArgNode,
+        alt((
+            join((t(Type), ident::parse_id_any, t(Equal), parse_type)),
+            join((
+                t(Const),
+                ident::parse_id_any,
+                t(Equal),
+                expression::parse_expression,
+            )),
+            join((
+                // TODO: unexpect `unsafe`
+                alt((t(Function), t(Node))),
+                ident::parse_id_any,
+                t(Equal),
+                parse_effective_node,
+            )),
+            join((
+                ident::parse_id_any,
+                t(Equal),
+                alt((
+                    parse_predef_op,
+                    parse_surely_node,
+                    parse_surely_type,
+                    // TODO: check if that works, normally it's a SimpleExp but I guess we can verify the
+                    //       simpleness of the expression at post-parsing time
+                    expression::parse_expression,
+                )),
+            )),
+        )),
+    )(input)
 }
 
 pub fn parse_surely_node<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {

--- a/rustre-parser/src/parser/static_rules.rs
+++ b/rustre-parser/src/parser/static_rules.rs
@@ -16,10 +16,13 @@ pub fn parse_static_param<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'
     node(
         StaticParamNode,
         alt((
-            join((t(Type), expect(parse_id_any, "expected id after `type`"))),
+            join((
+                t(Type),
+                expect(ident::parse_id_any, "expected id after `type`"),
+            )),
             join((
                 t(Const),
-                expect(parse_id_any, "expected id after `const`"),
+                expect(ident::parse_id_any, "expected id after `const`"),
                 expect(
                     join((t(Colon), expect(parse_type, "expected type after colon"))),
                     "const static param must specify a type",
@@ -29,7 +32,7 @@ pub fn parse_static_param<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'
                 nodes::parse_node_type,
                 expect(
                     join((
-                        parse_id_any,
+                        ident::parse_id_any,
                         expect(
                             nodes::parse_params_and_returns,
                             "signature must include params and return values",
@@ -45,7 +48,7 @@ pub fn parse_static_param<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'
 pub fn parse_effective_node<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
     node(
         EffectiveNodeNode,
-        join((parse_id_any, opt(parse_static_args))),
+        join((ident::parse_id_any, opt(parse_static_args))),
     )(input)
 }
 
@@ -101,7 +104,10 @@ pub fn parse_named_static_arg<'slice, 'src>(input: Input<'slice, 'src>) -> IResu
 }
 
 pub fn parse_surely_node<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    node(EffectiveNodeNode, join((parse_id_any, parse_static_args)))(input)
+    node(
+        EffectiveNodeNode,
+        join((ident::parse_id_any, parse_static_args)),
+    )(input)
 }
 
 pub fn parse_surely_type<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {

--- a/rustre-parser/src/parser/type_decl.rs
+++ b/rustre-parser/src/parser/type_decl.rs
@@ -10,7 +10,7 @@ pub fn parse_type_decls<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'sl
 
 pub fn parse_one_type_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
     join((
-        parse_lv6_id,
+        ident::parse_lv6_id,
         opt(join((
             t(Equal),
             expect(
@@ -28,7 +28,7 @@ fn parse_enum_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 
         join((
             t(Enum),
             expect(
-                many_delimited(t(OpenBrace), parse_lv6_id, t(Comma), t(CloseBrace)),
+                many_delimited(t(OpenBrace), ident::parse_lv6_id, t(Comma), t(CloseBrace)),
                 "missing `{}` after `enum`",
             ),
         )),

--- a/rustre-parser/src/parser/type_decl.rs
+++ b/rustre-parser/src/parser/type_decl.rs
@@ -1,0 +1,51 @@
+use super::*;
+
+pub fn parse_type_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    join((t(Type), expect(parse_type_decls, "missing type name")))(input)
+}
+
+pub fn parse_type_decls<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    many_delimited(success, parse_one_type_decl, success, peek_neg(t(Ident)))(input)
+}
+
+pub fn parse_one_type_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    join((
+        parse_lv6_id,
+        opt(join((
+            t(Equal),
+            expect(
+                alt((parse_type, parse_enum_decl, parse_struct_decl)),
+                "expected a struct/enum declaration or an existing type expression",
+            ),
+        ))),
+        expect(t(Semicolon), "expected `;` after type declaration"),
+    ))(input)
+}
+
+fn parse_enum_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        EnumDeclNode,
+        join((
+            t(Enum),
+            expect(
+                many_delimited(t(OpenBrace), parse_lv6_id, t(Comma), t(CloseBrace)),
+                "missing `{}` after `enum`",
+            ),
+        )),
+    )(input)
+}
+
+fn parse_struct_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
+    node(
+        StructDeclNode,
+        join((
+            opt(t(Struct)),
+            many_delimited(
+                t(OpenBrace),
+                nodes::parse_typed_valued_lv6_id,
+                t(Semicolon),
+                join((opt(t(Semicolon)), t(CloseBrace))),
+            ),
+        )),
+    )(input)
+}

--- a/rustre-parser/src/parser/type_decl.rs
+++ b/rustre-parser/src/parser/type_decl.rs
@@ -5,7 +5,15 @@ pub fn parse_type_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'sli
 }
 
 pub fn parse_type_decls<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
-    many_delimited(success, parse_one_type_decl, success, peek_neg(t(Ident)))(input)
+    many_delimited(
+        success,
+        join((
+            parse_one_type_decl,
+            expect(t(Semicolon), "expected `;` after type declaration"),
+        )),
+        success,
+        peek_neg(t(Ident)),
+    )(input)
 }
 
 pub fn parse_one_type_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<'slice, 'src> {
@@ -18,7 +26,6 @@ pub fn parse_one_type_decl<'slice, 'src>(input: Input<'slice, 'src>) -> IResult<
                 "expected a struct/enum declaration or an existing type expression",
             ),
         ))),
-        expect(t(Semicolon), "expected `;` after type declaration"),
     ))(input)
 }
 

--- a/rustre-parser/src/rowan_nom.rs
+++ b/rustre-parser/src/rowan_nom.rs
@@ -1,0 +1,388 @@
+use nom::combinator::map;
+use nom::Parser;
+use rowan::{GreenNode, GreenToken, NodeOrToken, SyntaxKind, SyntaxNode};
+
+pub trait RowanNomLanguage: rowan::Language {
+    /// Returns `true` if the token is a trivia token (whitespace or comment)
+    fn is_trivia(_kind: Self::Kind) -> bool {
+        false
+    }
+
+    fn get_error_kind() -> Self::Kind;
+}
+
+// Yup, that's a trait alias
+use RowanNomLanguage as Language;
+
+type RichToken<'src, Lang> = (<Lang as rowan::Language>::Kind, &'src str);
+
+pub struct Input<'slice, 'src, Lang: Language> {
+    src_pos: usize,
+    trivia_tokens: &'slice [RichToken<'src, Lang>],
+    trivia_tokens_text_len: usize,
+    tokens: &'slice [RichToken<'src, Lang>],
+}
+
+fn split_slice_predicate<T>(slice: &[T], predicate: impl FnMut(&T) -> bool) -> (&[T], &[T]) {
+    let non_trivia_idx = slice.iter().position(predicate).unwrap_or(slice.len());
+
+    slice.split_at(non_trivia_idx)
+}
+
+impl<'slice, 'src, Lang: Language> Input<'slice, 'src, Lang> {
+    /// Advances to the next token
+    ///
+    /// Panics if the input is empty
+    fn next(self) -> Self {
+        match self.tokens {
+            [] => panic!("empty input"),
+            [first, rest @ ..] => Input {
+                src_pos: self.src_pos + self.trivia_tokens_text_len + first.1.len(),
+                trivia_tokens: &[],
+                trivia_tokens_text_len: 0,
+                tokens: rest,
+            }
+            .advance_trivia(),
+        }
+    }
+
+    fn next_raw(&mut self) {
+        if let Some(trivia) = self.trivia_tokens.first() {
+            let text_len = trivia.1.len();
+            self.src_pos += text_len;
+            self.trivia_tokens_text_len -= text_len;
+            self.trivia_tokens = &self.trivia_tokens[1..];
+        } else if let Some(token) = self.tokens.first() {
+            self.src_pos += token.1.len();
+            self.tokens = &self.tokens[1..];
+        } else {
+            panic!("empty input");
+        }
+    }
+
+    fn advance_trivia(self) -> Self {
+        let (trivia_tokens, rest_tokens) =
+            split_slice_predicate(self.tokens, |(t, _)| !Lang::is_trivia(*t));
+
+        let trivia_tokens_text_len = trivia_tokens.iter().map(|(_, s)| s.len()).sum();
+
+        Self {
+            src_pos: self.src_pos,
+            trivia_tokens,
+            trivia_tokens_text_len,
+            tokens: rest_tokens,
+        }
+    }
+}
+
+impl<'slice, 'src, Lang: Language> Clone for Input<'slice, 'src, Lang> {
+    fn clone(&self) -> Self {
+        Self {
+            src_pos: self.src_pos,
+            trivia_tokens: self.trivia_tokens,
+            trivia_tokens_text_len: self.trivia_tokens_text_len,
+            tokens: self.tokens,
+        }
+    }
+}
+
+impl<'slice, 'src, Lang: Language> From<&'slice [RichToken<'src, Lang>]>
+    for Input<'slice, 'src, Lang>
+{
+    fn from(tokens: &'slice [RichToken<'src, Lang>]) -> Self {
+        Self {
+            src_pos: 0,
+            trivia_tokens: &[],
+            trivia_tokens_text_len: 0,
+            tokens,
+        }
+        .advance_trivia()
+    }
+}
+
+impl<'slice, 'src, Lang: Language> nom::InputLength for Input<'slice, 'src, Lang> {
+    fn input_len(&self) -> usize {
+        self.trivia_tokens.len() + self.tokens.len()
+    }
+}
+
+/// TODO <Language> should be a phantom type parameter here
+pub struct Children<E> {
+    errors: Vec<E>,
+    inner: Vec<NodeOrToken<GreenNode, GreenToken>>,
+}
+
+impl<E> Children<E> {
+    fn empty() -> Self {
+        Self {
+            errors: vec![],
+            inner: vec![],
+        }
+    }
+
+    fn from_tokens<'src, Lang: Language, I: IntoIterator<Item = (Lang::Kind, &'src str)>>(
+        iter: I,
+    ) -> Self {
+        Self {
+            errors: vec![],
+            inner: iter
+                .into_iter()
+                .map(|(token, str)| {
+                    NodeOrToken::Token(GreenToken::new(Lang::kind_to_raw(token), str))
+                })
+                .collect(),
+        }
+    }
+
+    fn from_err<Lang: Language>(error: E) -> Self {
+        Self {
+            errors: vec![error],
+            // TODO include inner non-matched nodes/tokens ?
+            inner: vec![NodeOrToken::Node(GreenNode::new(
+                Lang::kind_to_raw(Lang::get_error_kind()),
+                [],
+            ))],
+        }
+    }
+
+    fn from_rowan_children(children: rowan::Children, errors: Vec<E>) -> Self {
+        Self {
+            errors,
+            inner: children
+                .map(|e| match e {
+                    NodeOrToken::Token(t) => NodeOrToken::Token(t.to_owned()),
+                    NodeOrToken::Node(n) => NodeOrToken::Node(n.to_owned()),
+                })
+                .collect(),
+        }
+    }
+
+    fn add(&mut self, other: Self) {
+        self.errors.extend(other.errors);
+        self.inner.extend(other.inner);
+    }
+
+    fn into_node(self, kind: SyntaxKind) -> Self {
+        Self {
+            errors: self.errors,
+            inner: vec![NodeOrToken::Node(GreenNode::new(kind, self.inner))],
+        }
+    }
+}
+
+pub trait RowanNomError {
+    fn from_message(message: &str) -> Self;
+    // TODO add much more errors (i.e. from_eof(positon: usize))
+    // TODO include location information in constructors
+}
+
+pub type IResult<'slice, 'src, Lang, E, IE = E> =
+    nom::IResult<Input<'slice, 'src, Lang>, Children<E>, IE>;
+pub type RootIResult<'slice, 'src, Lang, E, IE = E> =
+    nom::IResult<Input<'slice, 'src, Lang>, (SyntaxNode<Lang>, Vec<E>), IE>;
+
+pub fn t<'slice, 'src: 'slice, Lang: Language, E, IE: RowanNomError>(
+    token: Lang::Kind,
+) -> impl FnMut(Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE> {
+    move |input| {
+        if let Some((current_token, current_token_str)) = input.tokens.first() {
+            if *current_token == token {
+                let trivia = input.trivia_tokens;
+                Ok((
+                    input.next(),
+                    Children::from_tokens::<Lang, _>(
+                        trivia
+                            .iter()
+                            .cloned()
+                            .chain(std::iter::once((*current_token, *current_token_str))),
+                    ),
+                ))
+            } else {
+                Err(nom::Err::Error(IE::from_message("unexpected token")))
+            }
+        } else {
+            Err(nom::Err::Error(IE::from_message("unexpected eof")))
+        }
+    }
+}
+
+pub fn fallible_with<'slice, 'src: 'slice, Lang: Language, E, IE>(
+    mut parser: impl Parser<Input<'slice, 'src, Lang>, Children<E>, IE>,
+    mut convert: impl FnMut(IE) -> E,
+) -> impl FnMut(Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE>
+where
+    Lang::Kind: 'static,
+{
+    move |input| {
+        let conv = &mut convert;
+        parser.parse(input.clone()).or_else(move |e| match e {
+            nom::Err::Error(e) => Ok((input, Children::from_err::<Lang>(conv(e)))),
+            other => Err(other),
+        })
+    }
+}
+
+pub fn fallible<'slice, 'src: 'slice, Lang: Language, E, IE>(
+    parser: impl Parser<Input<'slice, 'src, Lang>, Children<E>, IE>,
+) -> impl FnMut(Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE>
+where
+    Lang::Kind: 'static,
+    E: From<IE>,
+{
+    fallible_with(parser, Into::into)
+}
+
+/// Wraps the contained parser's direct and indirect output into a node
+pub fn node<'slice, 'src: 'slice, Lang: Language, E, IE>(
+    node: Lang::Kind,
+    parser: impl Parser<Input<'slice, 'src, Lang>, Children<E>, IE>,
+) -> impl FnOnce(Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE>
+where
+    Lang::Kind: 'static,
+{
+    let syntax = Lang::kind_to_raw(node);
+    move |input| map(parser, |c| c.into_node(syntax))(input)
+}
+
+/// Wraps the contained parser's output into a root node inside a [SyntaxNode]
+pub fn root_node<'slice, 'src: 'slice, Lang: Language, E, IE>(
+    node: Lang::Kind,
+    parser: impl Parser<Input<'slice, 'src, Lang>, Children<E>, IE>,
+) -> impl FnOnce(Input<'slice, 'src, Lang>) -> RootIResult<'slice, 'src, Lang, E, IE>
+where
+    Lang::Kind: 'static,
+{
+    let syntax = Lang::kind_to_raw(node);
+    move |input| {
+        map(parser, |c| {
+            (
+                SyntaxNode::new_root(GreenNode::new(syntax, c.inner)),
+                c.errors,
+            )
+        })(input)
+    }
+}
+
+pub trait Joignable<'slice, 'src, Lang: Language, E, IE> {
+    fn parse(&mut self, input: Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE>;
+}
+
+macro_rules! impl_tuple {
+    ($arg0:ident, $($arg:ident),*) => {
+        #[allow(unused_parens)]
+        impl<'slice, 'src: 'slice, Lang: Language, CE, IE, $arg0, $($arg),*> Joignable<'slice, 'src, Lang, CE, IE> for ($arg0, $($arg,)*)
+        where
+            Lang::Kind: 'static,
+            $arg0: Parser<Input<'slice, 'src, Lang>, Children<CE>, IE>,
+            $($arg: Parser<Input<'slice, 'src, Lang>, Children<CE>, IE>),*
+        {
+            fn parse(&mut self, input: Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, CE, IE> {
+                #[allow(non_snake_case)]
+                let ($arg0, $($arg),*) = self;
+
+                #[allow(unused_mut)]
+                let (input, mut children) = $arg0.parse(input)?;
+                $(let (input, children2) = $arg.parse(input)?; children.add(children2);)*
+
+                Ok((input, children))
+            }
+        }
+    };
+}
+
+impl_tuple!(A,);
+impl_tuple!(A, B);
+impl_tuple!(A, B, C);
+impl_tuple!(A, B, C, D);
+impl_tuple!(A, B, C, D, E);
+impl_tuple!(A, B, C, D, E, F);
+impl_tuple!(A, B, C, D, E, F, G);
+impl_tuple!(A, B, C, D, E, F, G, H);
+impl_tuple!(A, B, C, D, E, F, G, H, I);
+impl_tuple!(A, B, C, D, E, F, G, H, I, J);
+impl_tuple!(A, B, C, D, E, F, G, H, I, J, K);
+impl_tuple!(A, B, C, D, E, F, G, H, I, J, K, L);
+impl_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M);
+
+/// Joins the output trees of multiple parsers without creating a new node (yet)
+pub fn join<'slice, 'src: 'slice, Lang: Language, E, IE>(
+    mut parsers: impl Joignable<'slice, 'src, Lang, E, IE>,
+) -> impl FnMut(Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE> {
+    move |input| parsers.parse(input)
+}
+
+/// Repeats the given parser 0 or more times until it fails, and join all the results in a
+/// `Children` object
+pub fn many0<'slice, 'src: 'slice, E, Lang: Language, IE>(
+    mut parser: impl Parser<Input<'slice, 'src, Lang>, Children<E>, E>,
+) -> impl FnMut(Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE>
+where
+    Lang::Kind: 'static,
+{
+    move |input| {
+        let (mut input, mut first) = match parser.parse(input.clone()) {
+            Ok(x) => x,
+            Err(_) => return Ok((input, Children::empty())),
+        };
+
+        while let Ok((new_input, new_children)) = parser.parse(input.clone()) {
+            input = new_input;
+            first.add(new_children);
+        }
+
+        Ok((input, first))
+    }
+}
+
+/// FIXME: remove all the following once the nom migration is complete
+pub mod adapter {
+    use super::*;
+    use crate::parser::Parser;
+    use rowan::GreenNodeBuilder;
+
+    const DUMMY_SYNTAX: SyntaxKind = SyntaxKind(65535);
+
+    pub fn old_style<'slice, 'src: 'slice, IE: RowanNomError>(
+        f: impl Fn(&mut Parser<'src>) -> bool,
+    ) -> impl FnMut(
+        Input<'slice, 'src, crate::LustreLang>,
+    ) -> IResult<'slice, 'src, crate::LustreLang, crate::Error, IE> {
+        move |input| {
+            let mut builder = GreenNodeBuilder::new();
+            builder.start_node(DUMMY_SYNTAX);
+
+            let mut parser = Parser {
+                tokens: input
+                    .trivia_tokens
+                    .iter()
+                    .chain(input.tokens)
+                    .rev()
+                    .cloned()
+                    .collect(),
+                builder,
+                errors: vec![],
+                pos: input.src_pos,
+            };
+
+            if f(&mut parser) {
+                parser.builder.finish_node();
+
+                let consumed = input.tokens.len() + input.trivia_tokens.len() - parser.tokens.len();
+                let mut input2 = input;
+                for _ in 0..consumed {
+                    input2.next_raw();
+                }
+
+                Ok((
+                    input2,
+                    Children::from_rowan_children(
+                        parser.builder.finish().children(),
+                        parser.errors,
+                    ),
+                ))
+            } else {
+                Err(nom::Err::Error(IE::from_message("parser failed")))
+            }
+        }
+    }
+}

--- a/rustre-parser/src/rowan_nom.rs
+++ b/rustre-parser/src/rowan_nom.rs
@@ -1,10 +1,10 @@
+mod children;
 mod error;
 
+pub use children::Children;
 pub use error::*;
-use nom::combinator::map;
 use nom::Parser;
-use rowan::{GreenNode, GreenToken, NodeOrToken, SyntaxKind, SyntaxNode};
-use std::marker::PhantomData;
+use rowan::{SyntaxKind, SyntaxNode};
 
 pub trait RowanNomLanguage: rowan::Language {
     /// Returns `true` if the token is a trivia token (whitespace or comment)
@@ -34,23 +34,38 @@ fn split_slice_predicate<T>(slice: &[T], predicate: impl FnMut(&T) -> bool) -> (
 }
 
 impl<'slice, 'src, Lang: Language> Input<'slice, 'src, Lang> {
-    /// Advances to the next token
-    ///
-    /// Panics if the input is empty
-    fn next(self) -> Self {
+    pub fn src_pos(&self) -> usize {
+        self.src_pos
+    }
+
+    fn next(
+        &self,
+    ) -> Option<(
+        Self,
+        (
+            &'slice [RichToken<'src, Lang>],
+            &'slice RichToken<'src, Lang>,
+        ),
+    )> {
         match self.tokens {
-            [] => panic!("empty input"),
-            [first, rest @ ..] => Input {
-                src_pos: self.src_pos + self.trivia_tokens_text_len + first.1.len(),
-                trivia_tokens: &[],
-                trivia_tokens_text_len: 0,
-                tokens: rest,
+            [] => None,
+            [first, rest @ ..] => {
+                let relevant_tokens = (self.trivia_tokens, first);
+
+                let input = Input {
+                    src_pos: self.src_pos + self.trivia_tokens_text_len + first.1.len(),
+                    trivia_tokens: &[],
+                    trivia_tokens_text_len: 0,
+                    tokens: rest,
+                }
+                .advance_trivia();
+
+                Some((input, relevant_tokens))
             }
-            .advance_trivia(),
         }
     }
 
-    fn next_trivia(self) -> Option<(Self, &'slice RichToken<'src, Lang>)> {
+    fn next_trivia(&self) -> Option<(Self, &'slice RichToken<'src, Lang>)> {
         if let [token, rest @ ..] = self.trivia_tokens {
             let token_len = token.1.len();
 
@@ -122,115 +137,79 @@ impl<'slice, 'src, Lang: Language> From<&'slice [RichToken<'src, Lang>]>
     }
 }
 
-impl<'slice, 'src, Lang: Language> nom::InputLength for Input<'slice, 'src, Lang> {
-    fn input_len(&self) -> usize {
-        self.trivia_tokens.len() + self.tokens.len()
-    }
-}
-
-pub struct Children<Lang: Language, E> {
-    errors: Vec<E>,
-    inner: Vec<NodeOrToken<GreenNode, GreenToken>>,
-    _lang: PhantomData<Lang>,
-}
-
-impl<Lang: Language, E> Default for Children<Lang, E> {
-    fn default() -> Self {
-        Self {
-            errors: vec![],
-            inner: vec![],
-            _lang: PhantomData,
-        }
-    }
-}
-
-impl<Lang: Language, E> Children<Lang, E> {
-    fn empty() -> Self {
-        Self::default()
-    }
-
-    fn from_tokens<'src, I: IntoIterator<Item = (Lang::Kind, &'src str)>>(iter: I) -> Self {
-        Self {
-            inner: iter
-                .into_iter()
-                .map(|(token, str)| {
-                    NodeOrToken::Token(GreenToken::new(Lang::kind_to_raw(token), str))
-                })
-                .collect(),
-            ..Self::default()
-        }
-    }
-
-    fn from_err(error: E) -> Self {
-        Self {
-            errors: vec![error],
-            // TODO include inner non-matched nodes/tokens ?
-            inner: vec![NodeOrToken::Node(GreenNode::new(
-                Lang::kind_to_raw(Lang::get_error_kind()),
-                [],
-            ))],
-            ..Self::default()
-        }
-    }
-
-    fn from_rowan_children(children: rowan::Children, errors: Vec<E>) -> Self {
-        Self {
-            errors,
-            inner: children
-                .map(|e| match e {
-                    NodeOrToken::Token(t) => NodeOrToken::Token(t.to_owned()),
-                    NodeOrToken::Node(n) => NodeOrToken::Node(n.to_owned()),
-                })
-                .collect(),
-            ..Self::default()
-        }
-    }
-
-    fn add(&mut self, other: Self) {
-        self.errors.extend(other.errors);
-        self.inner.extend(other.inner);
-    }
-
-    fn into_node(self, kind: Lang::Kind) -> Self {
-        Self {
-            errors: self.errors,
-            inner: vec![NodeOrToken::Node(GreenNode::new(
-                Lang::kind_to_raw(kind),
-                self.inner,
-            ))],
-            ..Self::default()
-        }
-    }
-}
-
 pub type IResult<'slice, 'src, Lang, E, IE = E> =
     nom::IResult<Input<'slice, 'src, Lang>, Children<Lang, E>, IE>;
 pub type RootIResult<'slice, 'src, Lang, E, IE = E> =
     nom::IResult<Input<'slice, 'src, Lang>, (SyntaxNode<Lang>, Vec<E>), IE>;
+
+/// Succeeds without consuming the input
+///
+/// May be used as an [alt] case
+pub fn success<'slice, 'src: 'slice, Lang: Language, E, IE>(
+    input: Input<'slice, 'src, Lang>,
+) -> IResult<'slice, 'src, Lang, E, IE> {
+    Ok((input, Children::empty()))
+}
+
+/// Succeeds if the input contains no tokens other than trivia, and returns a [Children] object with
+/// said trivia, effectively emptying last insignificant bits of input
+pub fn eof<'slice, 'src: 'slice, Lang: Language, E, IE: RowanNomError<Lang>>(
+    input: Input<'slice, 'src, Lang>,
+) -> IResult<'slice, 'src, Lang, E, IE> {
+    if input.tokens.is_empty() {
+        let trivia_tokens = input.trivia_tokens.into_iter();
+
+        let input = Input {
+            src_pos: input.src_pos + input.trivia_tokens_text_len,
+            trivia_tokens: &[],
+            trivia_tokens_text_len: 0,
+            tokens: &[],
+        };
+
+        Ok((input, trivia_tokens.collect()))
+    } else {
+        Err(nom::Err::Error(IE::from_message(
+            "expected eof, found token",
+        )))
+    }
+}
+
+pub fn t_any<'slice, 'src: 'slice, Lang: Language, E, IE: RowanNomError<Lang>>(
+    input: Input<'slice, 'src, Lang>,
+) -> IResult<'slice, 'src, Lang, E, IE> {
+    if let Some((new_input, (trivia, current_token))) = input.next() {
+        Ok((
+            new_input,
+            trivia
+                .iter()
+                .chain(std::iter::once(current_token))
+                .collect(),
+        ))
+    } else {
+        Err(nom::Err::Error(IE::from_unexpected_eof(input.src_pos)))
+    }
+}
 
 /// Parses only the given token, fails if the wrong token is read or if the input is empty
 ///
 /// Trivia tokens are automatically skipped and prepended to the parsed token
 pub fn t<'slice, 'src: 'slice, Lang: Language, E, IE: RowanNomError<Lang>>(
     token: Lang::Kind,
-) -> impl FnMut(Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE> {
+) -> impl FnMut(Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE> + Clone + Copy {
     debug_assert!(
         !Lang::is_trivia(token),
         "this parser will always fail with trivia tokens, please use `t_raw`"
     );
 
     move |input| {
-        if let Some((current_token, current_token_str)) = input.tokens.first() {
-            if *current_token == token {
-                let trivia = input.trivia_tokens;
+        if let Some((new_input, (trivia, current_token))) = input.next() {
+            if current_token.0 == token {
                 Ok((
-                    input.next(),
-                    Children::from_tokens(
-                        trivia
-                            .iter()
-                            .cloned()
-                            .chain(std::iter::once((*current_token, *current_token_str))),
-                    ),
+                    new_input,
+                    trivia
+                        .iter()
+                        .chain(std::iter::once(current_token))
+                        .collect(),
                 ))
             } else {
                 Err(nom::Err::Error(IE::from_message("unexpected token")))
@@ -248,7 +227,7 @@ pub fn t<'slice, 'src: 'slice, Lang: Language, E, IE: RowanNomError<Lang>>(
 /// context
 pub fn t_raw<'slice, 'src: 'slice, Lang: Language, E, IE: RowanNomError<Lang>>(
     token: Lang::Kind,
-) -> impl FnMut(Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE> {
+) -> impl FnMut(Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE> + Clone + Copy {
     let is_trivia = Lang::is_trivia(token);
 
     move |input| {
@@ -257,10 +236,7 @@ pub fn t_raw<'slice, 'src: 'slice, Lang: Language, E, IE: RowanNomError<Lang>>(
         if is_trivia {
             if let Some((new_input, current_token)) = input.next_trivia() {
                 if current_token.0 == token {
-                    Ok((
-                        new_input,
-                        Children::from_tokens(std::iter::once(*current_token)),
-                    ))
+                    Ok((new_input, std::iter::once(current_token).collect()))
                 } else {
                     Err(nom::Err::Error(IE::from_message("unexpected token")))
                 }
@@ -312,30 +288,30 @@ where
 /// Wraps the contained parser's direct and indirect output into a node
 pub fn node<'slice, 'src: 'slice, Lang: Language, E, IE>(
     node: Lang::Kind,
-    parser: impl Parser<Input<'slice, 'src, Lang>, Children<Lang, E>, IE>,
-) -> impl FnOnce(Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE>
+    mut parser: impl Parser<Input<'slice, 'src, Lang>, Children<Lang, E>, IE>,
+) -> impl FnMut(Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE>
 where
     Lang::Kind: 'static,
 {
-    move |input| map(parser, |c| c.into_node(node))(input)
+    move |input| {
+        parser
+            .parse(input)
+            .map(|(input, c)| (input, c.into_node(node)))
+    }
 }
 
 /// Wraps the contained parser's output into a root node inside a [SyntaxNode]
 pub fn root_node<'slice, 'src: 'slice, Lang: Language, E, IE>(
     node: Lang::Kind,
-    parser: impl Parser<Input<'slice, 'src, Lang>, Children<Lang, E>, IE>,
-) -> impl FnOnce(Input<'slice, 'src, Lang>) -> RootIResult<'slice, 'src, Lang, E, IE>
+    mut parser: impl Parser<Input<'slice, 'src, Lang>, Children<Lang, E>, IE>,
+) -> impl FnMut(Input<'slice, 'src, Lang>) -> RootIResult<'slice, 'src, Lang, E, IE>
 where
     Lang::Kind: 'static,
 {
-    let syntax = Lang::kind_to_raw(node);
     move |input| {
-        map(parser, |c| {
-            (
-                SyntaxNode::new_root(GreenNode::new(syntax, c.inner)),
-                c.errors,
-            )
-        })(input)
+        parser
+            .parse(input)
+            .map(|(input, c)| (input, c.into_root_node(node)))
     }
 }
 
@@ -343,7 +319,7 @@ pub trait Joignable<'slice, 'src, Lang: Language, E, IE> {
     fn parse(&mut self, input: Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE>;
 }
 
-macro_rules! impl_tuple {
+macro_rules! impl_joignable {
     ($arg0:ident, $($arg:ident),*) => {
         #[allow(unused_parens)]
         impl<'slice, 'src: 'slice, Lang: Language, CE, IE, $arg0, $($arg),*> Joignable<'slice, 'src, Lang, CE, IE> for ($arg0, $($arg,)*)
@@ -358,7 +334,7 @@ macro_rules! impl_tuple {
 
                 #[allow(unused_mut)]
                 let (input, mut children) = $arg0.parse(input)?;
-                $(let (input, children2) = $arg.parse(input)?; children.add(children2);)*
+                $(let (input, children2) = $arg.parse(input)?; children += children2;)*
 
                 Ok((input, children))
             }
@@ -366,19 +342,32 @@ macro_rules! impl_tuple {
     };
 }
 
-impl_tuple!(A,);
-impl_tuple!(A, B);
-impl_tuple!(A, B, C);
-impl_tuple!(A, B, C, D);
-impl_tuple!(A, B, C, D, E);
-impl_tuple!(A, B, C, D, E, F);
-impl_tuple!(A, B, C, D, E, F, G);
-impl_tuple!(A, B, C, D, E, F, G, H);
-impl_tuple!(A, B, C, D, E, F, G, H, I);
-impl_tuple!(A, B, C, D, E, F, G, H, I, J);
-impl_tuple!(A, B, C, D, E, F, G, H, I, J, K);
-impl_tuple!(A, B, C, D, E, F, G, H, I, J, K, L);
-impl_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M);
+impl_joignable!(A,);
+impl_joignable!(A, B);
+impl_joignable!(A, B, C);
+impl_joignable!(A, B, C, D);
+impl_joignable!(A, B, C, D, E);
+impl_joignable!(A, B, C, D, E, F);
+impl_joignable!(A, B, C, D, E, F, G);
+impl_joignable!(A, B, C, D, E, F, G, H);
+impl_joignable!(A, B, C, D, E, F, G, H, I);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K, L);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K, L, M);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K, L, M, N);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y);
+impl_joignable!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
 
 /// Joins the output trees of multiple parsers without creating a new node (yet)
 pub fn join<'slice, 'src: 'slice, Lang: Language, E, IE>(
@@ -437,6 +426,19 @@ impl_alt!(A, B, C, D, E, F, G, H, I, J);
 impl_alt!(A, B, C, D, E, F, G, H, I, J, K);
 impl_alt!(A, B, C, D, E, F, G, H, I, J, K, L);
 impl_alt!(A, B, C, D, E, F, G, H, I, J, K, L, M);
+impl_alt!(A, B, C, D, E, F, G, H, I, J, K, L, M, N);
+impl_alt!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
+impl_alt!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
+impl_alt!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q);
+impl_alt!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R);
+impl_alt!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S);
+impl_alt!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T);
+impl_alt!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U);
+impl_alt!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V);
+impl_alt!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W);
+impl_alt!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X);
+impl_alt!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y);
+impl_alt!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
 
 pub fn alt<'slice, 'src: 'slice, Lang: Language, E, IE>(
     mut parsers: impl Alt<'slice, 'src, Lang, E, IE>,
@@ -460,49 +462,10 @@ where
 
         while let Ok((new_input, new_children)) = parser.parse(input.clone()) {
             input = new_input;
-            first.add(new_children);
+            first += new_children;
         }
 
         Ok((input, first))
-    }
-}
-
-/// While the `end` parser doesn't succeed, run the first parser 0 or more times and join all the
-/// results in a `Children` object
-///
-/// If `end` hasn't yet found the end of the repetition and `parser` fails, the input will be
-/// advanced by one token and an unexpected token error will be inserted.
-///
-/// `end` is only used to determine when to stop parsing, it is just "peeked" ; the input won't be
-/// advanced and the output won't include its result.
-pub fn many0_terminated<'slice, 'src: 'slice, Lang: Language, E, IE>(
-    mut parser: impl Parser<Input<'slice, 'src, Lang>, Children<Lang, E>, IE>,
-    mut end: impl Parser<Input<'slice, 'src, Lang>, Children<Lang, E>, IE>,
-) -> impl FnMut(Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE>
-where
-    Lang::Kind: 'static,
-    E: RowanNomError<Lang>,
-{
-    move |mut input| {
-        let mut children = Children::empty();
-
-        loop {
-            if end.parse(input.clone()).is_ok() {
-                break Ok((input, children));
-            } else if let Ok((new_input, new_children)) = parser.parse(input.clone()) {
-                input = new_input;
-                children.add(new_children);
-            } else {
-                let err = if let Some(_first) = input.tokens.first().cloned() {
-                    input = input.next();
-                    E::from_message("unexpected token")
-                } else {
-                    E::from_message("unexpected eof")
-                };
-
-                children.add(Children::from_err(err));
-            }
-        }
     }
 }
 

--- a/rustre-parser/src/rowan_nom.rs
+++ b/rustre-parser/src/rowan_nom.rs
@@ -266,6 +266,22 @@ where
     }
 }
 
+/// Negated peek, succeeds only if the given parser fails
+///
+///   * On failure, succeeds with and empty [`Children`] and the same input
+///   * On success, fails
+pub fn peek_neg<'slice, 'src: 'slice, Lang: Language, E, IE: RowanNomError<Lang>>(
+    mut parser: impl Parser<Input<'slice, 'src, Lang>, Children<Lang, E>, IE>,
+) -> impl FnMut(Input<'slice, 'src, Lang>) -> IResult<'slice, 'src, Lang, E, IE>
+where
+    Lang::Kind: 'static,
+{
+    move |input| match parser.parse(input.clone()) {
+        Ok(_) => Err(nom::Err::Error(IE::from_message("neg_peek"))),
+        Err(_) => Ok((input, Children::empty())),
+    }
+}
+
 pub fn fallible_with<'slice, 'src: 'slice, Lang: Language, E, IE>(
     mut parser: impl Parser<Input<'slice, 'src, Lang>, Children<Lang, E>, IE>,
     mut convert: impl FnMut(IE) -> E,

--- a/rustre-parser/src/rowan_nom/children.rs
+++ b/rustre-parser/src/rowan_nom/children.rs
@@ -1,0 +1,115 @@
+use super::RowanNomLanguage as Language;
+use rowan::{GreenNode, GreenToken, NodeOrToken, SyntaxNode};
+use std::fmt::{Debug, Formatter};
+use std::marker::PhantomData;
+
+pub struct Children<Lang: Language, E> {
+    errors: Vec<E>,
+    inner: Vec<NodeOrToken<GreenNode, GreenToken>>,
+    _lang: PhantomData<Lang>,
+}
+
+impl<Lang: Language, E> Default for Children<Lang, E> {
+    fn default() -> Self {
+        Self {
+            errors: vec![],
+            inner: vec![],
+            _lang: PhantomData,
+        }
+    }
+}
+
+impl<Lang: Language, E: Debug> Debug for Children<Lang, E> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Children")
+            .field("inner", &self.inner)
+            .field("errors", &self.errors)
+            .finish()
+    }
+}
+
+impl<Lang: Language, E> Children<Lang, E> {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn from_err(error: E) -> Self {
+        Self {
+            errors: vec![error],
+            // TODO include inner non-matched nodes/tokens ?
+            inner: vec![NodeOrToken::Node(GreenNode::new(
+                Lang::kind_to_raw(Lang::get_error_kind()),
+                [],
+            ))],
+            ..Self::default()
+        }
+    }
+
+    pub(super) fn from_rowan_children(children: rowan::Children, errors: Vec<E>) -> Self {
+        Self {
+            errors,
+            inner: children
+                .map(|e| match e {
+                    NodeOrToken::Token(t) => NodeOrToken::Token(t.to_owned()),
+                    NodeOrToken::Node(n) => NodeOrToken::Node(n.to_owned()),
+                })
+                .collect(),
+            ..Self::default()
+        }
+    }
+
+    pub fn into_node(self, kind: Lang::Kind) -> Self {
+        Self {
+            errors: self.errors,
+            inner: vec![NodeOrToken::Node(GreenNode::new(
+                Lang::kind_to_raw(kind),
+                self.inner,
+            ))],
+            ..Self::default()
+        }
+    }
+
+    pub fn into_root_node(self, kind: Lang::Kind) -> (SyntaxNode<Lang>, Vec<E>) {
+        let node = SyntaxNode::new_root(GreenNode::new(Lang::kind_to_raw(kind), self.inner));
+        (node, self.errors)
+    }
+}
+
+impl<'src, Lang: Language, E> FromIterator<super::RichToken<'src, Lang>> for Children<Lang, E> {
+    fn from_iter<T: IntoIterator<Item = super::RichToken<'src, Lang>>>(iter: T) -> Self {
+        Self {
+            inner: iter
+                .into_iter()
+                .map(|(token, str)| {
+                    NodeOrToken::Token(GreenToken::new(Lang::kind_to_raw(token), str))
+                })
+                .collect(),
+            ..Self::default()
+        }
+    }
+}
+
+impl<'src, 'a, Lang: Language, E> FromIterator<&'a super::RichToken<'src, Lang>>
+    for Children<Lang, E>
+{
+    fn from_iter<T: IntoIterator<Item = &'a super::RichToken<'src, Lang>>>(iter: T) -> Self {
+        Self::from_iter(iter.into_iter().map(|x| *x))
+    }
+}
+
+impl<Lang: Language, E> std::ops::Add for Children<Lang, E> {
+    type Output = Self;
+
+    fn add(mut self, rhs: Self) -> Self::Output {
+        self.errors.extend(rhs.errors);
+        self.inner.extend(rhs.inner);
+        self
+    }
+}
+
+impl<Lang: Language, E> std::ops::AddAssign for Children<Lang, E> {
+    fn add_assign(&mut self, rhs: Self) {
+        self.errors.extend(rhs.errors);
+        self.inner.extend(rhs.inner);
+    }
+}

--- a/rustre-parser/src/rowan_nom/error.rs
+++ b/rustre-parser/src/rowan_nom/error.rs
@@ -1,0 +1,13 @@
+use std::ops::Range;
+
+pub trait RowanNomError<Lang: super::Language> {
+    /// Generic error, should probably be ultimately removed
+    fn from_message(message: &str) -> Self;
+
+    /// Creates error: Attempted to read a token when there are none remaining
+    fn from_unexpected_eof(position: usize) -> Self;
+
+    fn from_unexpected_token(span: Range<usize>, expected: Lang::Kind, found: Lang::Kind) -> Self;
+
+    // TODO add much more errors, include location information in constructors
+}

--- a/rustre-parser/src/rowan_nom/error.rs
+++ b/rustre-parser/src/rowan_nom/error.rs
@@ -9,5 +9,7 @@ pub trait RowanNomError<Lang: super::Language> {
 
     fn from_unexpected_token(span: Range<usize>, expected: Lang::Kind, found: Lang::Kind) -> Self;
 
+    fn with_context(self, ctx: &'static str) -> Self;
+
     // TODO add much more errors, include location information in constructors
 }

--- a/rustre-parser/src/rowan_nom/error.rs
+++ b/rustre-parser/src/rowan_nom/error.rs
@@ -13,3 +13,30 @@ pub trait RowanNomError<Lang: super::Language> {
 
     // TODO add much more errors, include location information in constructors
 }
+
+/// A ZST that implements [`RowanNomError`] when details or context don't matter
+#[derive(Debug, Default, Clone, Copy, thiserror::Error)]
+#[error("dummy error used, can't provide further information")]
+pub struct DummyError;
+
+impl<Lang: super::Language> RowanNomError<Lang> for DummyError {
+    fn from_message(_message: &str) -> Self {
+        Self
+    }
+
+    fn from_unexpected_eof(_position: usize) -> Self {
+        Self
+    }
+
+    fn from_unexpected_token(
+        _span: Range<usize>,
+        _expected: Lang::Kind,
+        _found: Lang::Kind,
+    ) -> Self {
+        Self
+    }
+
+    fn with_context(self, _ctx: &'static str) -> Self {
+        Self
+    }
+}

--- a/rustre-parser/src/rowan_nom/error.rs
+++ b/rustre-parser/src/rowan_nom/error.rs
@@ -4,6 +4,10 @@ pub trait RowanNomError<Lang: super::Language> {
     /// Generic error, should probably be ultimately removed
     fn from_message(message: &str) -> Self;
 
+    fn from_expected(position: usize, message: &str) -> Self;
+
+    fn from_expected_eof(range: Range<usize>) -> Self;
+
     /// Creates error: Attempted to read a token when there are none remaining
     fn from_unexpected_eof(position: usize) -> Self;
 
@@ -21,6 +25,14 @@ pub struct DummyError;
 
 impl<Lang: super::Language> RowanNomError<Lang> for DummyError {
     fn from_message(_message: &str) -> Self {
+        Self
+    }
+
+    fn from_expected(_position: usize, _message: &str) -> Self {
+        Self
+    }
+
+    fn from_expected_eof(_range: Range<usize>) -> Self {
         Self
     }
 


### PR DESCRIPTION
The goal is to be able to parse a green AST using [`nom`](https://github.com/Geal/nom), so our parser looks nicer and is able to backtrack.

Ultimately, this will be extracted into its own library.